### PR TITLE
Test plugin args

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sessions store data about the progress of a run. The first step in a full
 testing run, then, is to initialize a session:
 
 ```
-cosmic-ray init --baseline=10 <session name> <top module name> <test directory>
+cosmic-ray init --baseline=10 <session name> <top module name> -- <test directory>
 ```
 
 This will create a database file called `<session name>.json`. Once this is

--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -80,7 +80,7 @@ where each token of the command is on a separate line.
 
 
 def handle_baseline(configuration):
-    """usage: cosmic-ray baseline [options] <top-module> <test-dir>
+    """usage: cosmic-ray baseline [options] <top-module> [-- <test-args> ...]
 
 Run an un-mutated baseline of <top-module> using the tests in <test-dir>.
 This is largely like running a "worker" process, with the difference
@@ -93,7 +93,7 @@ options:
     sys.path.insert(0, '')
     test_runner = cosmic_ray.plugins.get_test_runner(
             configuration['--test-runner'],
-            configuration['<test-dir>'])
+            configuration['<test-args>'])
 
     test_runner()
 
@@ -103,7 +103,7 @@ def _get_db_name(session_name):
 
 
 def handle_init(configuration):
-    """usage: cosmic-ray init [options] [--exclude-modules=P ...] (--timeout=T | --baseline=M) <session-name> <top-module> <test-dir>
+    """usage: cosmic-ray init [options] [--exclude-modules=P ...] (--timeout=T | --baseline=M) <session-name> <top-module> [-- <test-args> ...]
 
 Initialize a mutation testing run. The primarily creates a database of "work to
 be done" which describes all of the mutations and test runs that need to be
@@ -132,7 +132,7 @@ options:
         timeout = baseline_mult * cosmic_ray.timing.run_baseline(
             configuration['--test-runner'],
             configuration['<top-module>'],
-            configuration['<test-dir>'])
+            configuration['<test-args>'])
 
     LOG.info('timeout = {} seconds'.format(timeout))
 
@@ -150,7 +150,7 @@ options:
             modules,
             db,
             configuration['--test-runner'],
-            configuration['<test-dir>'],
+            configuration['<test-args>'],
             timeout)
 
 
@@ -262,12 +262,12 @@ List the available operator plugins.
 
 
 def handle_worker(config):
-    """usage: cosmic-ray worker [options] <module> <operator> <occurrence> <test-runner> <test-dir>
+    """usage: cosmic-ray worker [options] <module> <operator> <occurrence> <test-runner> [-- <test-args> ...]
 
 Run a worker process which performs a single mutation and test run. Each
 worker does a minimal, isolated chunk of work: it mutates the <occurence>-th
 instance of <operator> in <module>, runs the test suite defined by
-<test-runner> and <test-dir>, prints the results, and exits.
+<test-runner> and <test-args>, prints the results, and exits.
 
 Normally you won't run this directly. Rather, it will be launched by celery
 worker tasks.
@@ -281,7 +281,7 @@ options:
     operator = cosmic_ray.plugins.get_operator(config['<operator>'])
     test_runner = cosmic_ray.plugins.get_test_runner(
         config['<test-runner>'],
-        config['<test-dir>'])
+        config['<test-args>'])
 
     with open(os.devnull, 'w') as devnull, redirect_stdout(devnull):
         result_type, data = cosmic_ray.worker.worker(

--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -169,7 +169,7 @@ are already running.
 
 
 def handle_run(configuration):
-    """usage: cosmic-ray run [options] [--exclude-modules=P ...] (--timeout=T | --baseline=M) <session-name> <top-module> <test-dir>
+    """usage: cosmic-ray run [options] [--exclude-modules=P ...] (--timeout=T | --baseline=M) <session-name> <top-module> [-- <test-args> ...]
 
 This simply runs the "init" command followed by the "exec" command.
 

--- a/cosmic_ray/commands/execute.py
+++ b/cosmic_ray/commands/execute.py
@@ -9,11 +9,11 @@ def execute(work_db, purge_queue=True):
     executed, and records any results that arrive.
 
     """
-    test_runner, test_directory, timeout = work_db.get_work_parameters()
+    test_runner, test_args, timeout = work_db.get_work_parameters()
     try:
         results = cosmic_ray.tasks.worker.execute_work_items(
             test_runner,
-            test_directory,
+            test_args,
             timeout,
             work_db.pending_work)
 

--- a/cosmic_ray/commands/init.py
+++ b/cosmic_ray/commands/init.py
@@ -8,7 +8,7 @@ LOG = logging.getLogger()
 def init(modules,
          work_db,
          test_runner,
-         test_dir,
+         test_args,
          timeout):
     """Clear and initialize a work-db with work items.
 
@@ -21,7 +21,7 @@ def init(modules,
     counts = cosmic_ray.counting.count_mutants(modules, operators)
     work_db.set_work_parameters(
         test_runner=test_runner,
-        test_directory=test_dir,
+        test_args=test_args,
         timeout=timeout)
 
     work_db.clear_work_items()

--- a/cosmic_ray/plugins.py
+++ b/cosmic_ray/plugins.py
@@ -19,14 +19,14 @@ def operator_names():
     return ExtensionManager('cosmic_ray.operators').names()
 
 
-def get_test_runner(name, test_dir):
+def get_test_runner(name, test_args):
     """Get a test-runner instance by name.
     """
     test_runner_manager = driver.DriverManager(
         namespace='cosmic_ray.test_runners',
         name=name,
         invoke_on_load=True,
-        invoke_args=(test_dir,),
+        invoke_args=(test_args,),
     )
 
     return test_runner_manager.driver

--- a/cosmic_ray/testing/pytest_runner.py
+++ b/cosmic_ray/testing/pytest_runner.py
@@ -17,14 +17,17 @@ class ResultCollector:
 class PytestRunner(TestRunner):
     """A TestRunner using py.test.
 
-    This discovers all tests under `test_dir` and executes them.
+    This treats `test_args` as a list of arguments to `pytest.main()`. The args
+    are passed directly to that function, so see it's documentation for a
+    description of how the arguments are used.
+
     """
 
     def _run(self):
         collector = ResultCollector()
 
         with open(os.devnull, 'w') as devnull, redirect_stdout(devnull):
-            pytest.main(['-x', self.test_dir],
+            pytest.main(list(self.test_args),
                         plugins=[collector])
 
         return (

--- a/cosmic_ray/testing/test_runner.py
+++ b/cosmic_ray/testing/test_runner.py
@@ -24,14 +24,14 @@ class TestRunner(metaclass=abc.ABCMeta):
     supported by Cosmic Ray should be provided by a TestRunner
     implementation.
     """
-    def __init__(self, test_dir):
-        self._test_dir = test_dir
+    def __init__(self, test_args):
+        self._test_args = test_args
 
     @property
-    def test_dir(self):
-        """The directory containing the tests to be run.
+    def test_args(self):
+        """The sequence of arguments for the test runner.
         """
-        return self._test_dir
+        return self._test_args
 
     @abc.abstractmethod
     def _run(self):

--- a/cosmic_ray/testing/unittest_runner.py
+++ b/cosmic_ray/testing/unittest_runner.py
@@ -7,11 +7,15 @@ from .test_runner import TestRunner
 class UnittestRunner(TestRunner):  # pylint:disable=no-init, too-few-public-methods
     """A TestRunner using `unittest`'s discovery mechanisms.
 
-    This discovers all tests under `test_dir` and executes them.
+    This treats the first element of `test_args` as a directory. This discovers
+    all tests under that directory and executes them.
+
+    All elements in `test_args` after the first are ignored.
+
     """
 
     def _run(self):
-        suite = unittest.TestLoader().discover(self.test_dir)
+        suite = unittest.TestLoader().discover(self.test_args[0])
         result = unittest.TestResult()
         result.failfast = True
         suite.run(result)

--- a/cosmic_ray/timing.py
+++ b/cosmic_ray/timing.py
@@ -5,6 +5,7 @@ generic functionality.
 """
 
 import datetime
+import itertools
 import subprocess
 
 
@@ -39,12 +40,14 @@ class Timer:
         pass
 
 
-def run_baseline(test_runner, module_name, test_dir):
-    command = ('cosmic-ray',
-               'baseline',
-               '--test-runner={}'.format(test_runner),
-               module_name,
-               test_dir,)
+def run_baseline(test_runner, module_name, test_args):
+    command = list(itertools.chain(
+        ('cosmic-ray',
+         'baseline',
+         '--test-runner={}'.format(test_runner),
+         module_name,
+         '--',),
+        test_args))
 
     with Timer() as t:
         subprocess.call(command)

--- a/cosmic_ray/work_db.py
+++ b/cosmic_ray/work_db.py
@@ -9,7 +9,7 @@
 #  - operator name
 #  - occurrence
 #  - test runner name
-#  - test directory
+#  - test args
 #  - timeout
 #
 # What describes results?
@@ -91,26 +91,26 @@ class WorkDB:
         """
         return self._db.table('work-items')
 
-    def set_work_parameters(self, test_runner, test_directory, timeout):
+    def set_work_parameters(self, test_runner, test_args, timeout):
         """Set (replace) the work parameters for the session.
 
         Args:
           test_runner: The name of the test runner plugin to use.
-          test_directory: The directory containing tests to run.
+          test_args: The arguments to pass to the test runner.
           timeout: The timeout for tests.
         """
         table = self._work_parameters
         table.purge()
         table.insert({
             'test-runner': test_runner,
-            'test-directory': test_directory,
+            'test-args': test_args,
             'timeout': timeout,
         })
 
     def get_work_parameters(self):
         """Get the work parameters (if set) for the session.
 
-        Returns: a tuple of `(test-runner, test-directory, timeout)`.
+        Returns: a tuple of `(test-runner, test-args, timeout)`.
 
         Raises:
           ValueError: If there are no work parameters set for the session.
@@ -123,7 +123,7 @@ class WorkDB:
             raise ValueError('work-db has no work parameters')
 
         return (record['test-runner'],
-                record['test-directory'],
+                record['test-args'],
                 record['timeout'])
 
     def add_work_items(self, items):

--- a/test_project/cosmic-ray.pytest.conf
+++ b/test_project/cosmic-ray.pytest.conf
@@ -5,4 +5,6 @@ run
 --baseline=10
 adam_tests.pytest
 adam
+--
+-x
 tests

--- a/test_project/cosmic-ray.unittest.conf
+++ b/test_project/cosmic-ray.unittest.conf
@@ -5,4 +5,5 @@ run
 --baseline=10
 adam_tests.unittest
 adam
+--
 tests


### PR DESCRIPTION
You can now pass a list of arguments to `init` which get passed to the test runner. The test runner can do whatever it liked with the list.