### PR TITLE
Fix a bunch of typos and grammar problems in the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,19 +78,19 @@ created, you can start executing tests with the `exec` command:
 cosmic-ray exec <session name>
 ```
 
-Unless there are error, this won't print anything.
+Unless there are errors, this won't print anything.
 
 ### View the results
 
-Once the execution is complete (i.e. all mutations have been performed and
-tested), you can see the results of you session with the `report` command:
+Once the execution is complete (i.e., all mutations have been performed and
+tested), you can see the results of your session with the `report` command:
 
 ```
 cosmic-ray report <session name>
 ```
 
 This will print out a bunch of information about the work that was performed,
-including stuff about what kinds of mutants were created, which were killed, and
+including what kinds of mutants were created, which were killed, and
 – chillingly – which survived.
 
 **[Further documentation is available at readthedocs](http://cosmic-ray.readthedocs.org/en/latest/).**

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ mutants, here's what you do:
     ```
 
 This will print out a bunch of information about what Cosmic Ray did, including
-stuff about what kinds of mutants were created, which were killed, and –
+what kinds of mutants were created, which were killed, and –
 chillingly – which survived.
 
 ## Installation
@@ -79,7 +79,7 @@ create an executable called `cosmic-ray`.
 
 You'll often want to install Cosmic Ray into a virtual environment. However, you
 generally *don't* want to install it into its own. Rather, you want to install
-it into the virtual environment of the project you want to test. This ensure
+it into the virtual environment of the project you want to test. This ensures
 that the workers have access to the modules they are supposed to test.
 
 ### Installing RabbitMQ
@@ -171,7 +171,7 @@ between initialization and execution of the tests. It did all of its work using
 the `run` command.
 
 Recent versions of Cosmic Ray still support the `run` command. All this command
-does is first do an `init` followed be an `exec`. This can be convenient for
+does is first do an `init` followed by an `exec`. This can be convenient for
 small test runs.
 
 Be aware, however, that `init` **can destroy an existing session database**! If
@@ -201,7 +201,12 @@ subcommand:
 cosmic-ray test-runners
 ```
 
-Tests runners require information about which tests to run, flags controlling their behavior, and so forth. Since each test runner implementation takes different kinds of information, we allow users to pass arbitrary lists of arguments to test runners. When running the `cosmic-ray init` command, everything after the lone `--` token is passed verbatim to the test runner initializer.
+Test runners require information about which tests to run, flags controlling
+their behavior, and so forth. Since each test runner implementation takes
+different kinds of information, we allow users to pass arbitrary lists of
+arguments to test runners. When running the `cosmic-ray init` command,
+everything after the lone `--` token is passed verbatim to the test runner
+initializer.
 
 For example, the command:
 ```
@@ -213,7 +218,7 @@ runner initializer. This plugin passes this list directly to the `pytest.main()`
 function which treats them as command line arguments; in this case, it means
 "exit on first failure, only running tests under 'allele_tests' which match
 'test_foo'". Each test runner will accept different arguments, so see their
-documentation for details on who to use them.
+documentation for details on how to use them.
 
 ### Specifying test timeouts
 
@@ -222,7 +227,7 @@ mutations that result in infinite loops (or other pathological runtime
 effects). Cosmic Ray takes the simple approach of using a *timeout* to
 determine when to kill a test and consider it *incompetent*. That is,
 if a test of a mutant takes longer than the timeout, the test is
-killed an the mutant is marked incompetent.
+killed, and the mutant is marked incompetent.
 
 There are two ways to specify timeout values to Cosmic Ray. The first
 is through the `--timeout` flag for the `init` subcommand. This flags
@@ -320,7 +325,7 @@ Run the operator tests with `unittest` like this:
 cosmic-ray load cosmic-ray.unittest.conf
 ```
 
-View ther results of this test with `report`:
+View the results of this test with `report`:
 
 ```
 cosmic-ray report adam_tests.unittest
@@ -370,7 +375,7 @@ introducing mutation testing as well.
 ## Implementation
 
 Cosmic Ray works by parsing the module under test (MUT) and its
-submodules into a abstract syntax trees using
+submodules into abstract syntax trees using
 [the `ast` module](https://docs.python.org/3/library/ast.html). It
 then uses
 [the `ast.NodeTransformer` class](https://docs.python.org/3/library/ast.html#ast.NodeTransformer)
@@ -387,16 +392,16 @@ In effect, the mutation testing algorithm is something like this:
 for mod in modules_under_test:
     for op in mutation_operators:
         for site in mutation_sites(op, mod):
-	        mutant_ast = mutate_ast(op, mod, site)
-			replace_module(mod.name, compile(mutant_ast)
-
-	        try:
-			    if discover_and_run_tests():
-				    print('Oh no! The mutant survived!')
-				else:
-				    print('The mutant was killed.')
-	        except Exception:
-			    print('The mutant was incompetent.')
+            mutant_ast = mutate_ast(op, mod, site)
+            replace_module(mod.name, compile(mutant_ast)
+            
+            try:
+                if discover_and_run_tests():
+                    print('Oh no! The mutant survived!')
+                else:
+                    print('The mutant was killed.')
+            except Exception:
+                print('The mutant was incompetent.')
 ```
 
 Obviously this can result in a lot of tests, and it can take some time
@@ -405,7 +410,7 @@ if your test suite is large and/or slow.
 ### Scaling up with celery
 
 One of the main practical challenges to mutation testing is that it can take a
-long time. Even on moderately sized projects, you might needs millions of
+long time. Even on moderately sized projects, you might need millions of
 individual mutations and test runs. This can be prohibitive to run on a single
 system.
 
@@ -430,10 +435,10 @@ corrupt the runtime of the worker processes. And ultimately the cost of starting
 the process is likely to be very small compared to the runtime of the test
 suite.
 
-By it's nature, Celery lets you start workers on as many systems as you want,
+By its nature, Celery lets you start workers on as many systems as you want,
 all connected to the same task queue. So you could potentially have thousands of
 workers performing mutation testing runs, giving nearly perfect scaling! While
 not everyone has thousands of machines on hand to do their testing work, it's
 conceivable that Cosmic Ray will one day be able to work with machines on
 commodity cloud providers, meaning that highly-scaled mutation testing for
-Python will available to anyone who wants it.
+Python will be available to anyone who wants it.

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -23,8 +23,8 @@ Each operator is ultimately a subclass of
 `ast.NodeTransformer`. `NodeTransformer` is used to traverse and
 modify ASTs, so our operators work by hooking into the
 `NodeTransformer` protocol to add and remove nodes from the AST. When
-an operator visits a potential mutation site (i.e. a node that it
-knows how to mutate) it informs the `Operator` machinery which in turn
+an operator visits a potential mutation site (i.e., a node that it
+knows how to mutate), it informs the `Operator` machinery, which in turn
 decides if the mutation should be supplied.
 
 An operator always operates on a copy of the original AST. In this way
@@ -39,7 +39,7 @@ To implement a new operator you need to create a subclass of
 `ast.NodeTransformer`. The `NodeTransformer` class provides a number of
 `visit_*` functions which are called during AST traversal as different types of
 nodes are visited. Examples include `visit_Num` which is called when a `Number`
-node is visitied, or `visit_UnaryOp` which is called when a unary operator is
+node is visited, or `visit_UnaryOp` which is called when a unary operator is
 visited. Your operator class should override the `visit_*` functions that it
 needs in order to determine when it can apply its mutation. In any of these
 functions, if your operator can perform a mutation it should call
@@ -47,7 +47,7 @@ functions, if your operator can perform a mutation it should call
 
 Your operator class should also implement `Operator.mutate()`. This is
 the function that actually mutates the AST by adding or removing
-nodes. This method will only over be called with nodes for which your
+nodes. This method will only ever be called with nodes for which your
 operator called `visit_mutation_site()` during traversal. In other
 words, Cosmic Ray splits mutation into two phases:
 
@@ -138,7 +138,7 @@ reaches `Num` nodes. To do this, it implements `ast.NodeTransformer.visit_Num()`
 which is called when `Num` nodes are visited. Since our operator can mutate
 *any* `Num` node, it implements this method by simply calling
 `visit_mutation_site()`; remember that this informs the rest of the mutation
-machinery that its possible to perform a mutation at this node:
+machinery that it's possible to perform a mutation at this node:
 
 ```
     def visit_Num(self, node):
@@ -162,7 +162,7 @@ In this case, simply create a new `Num` node with a new value and return it:
 That's all there is to it. This mutation operator is now ready to be applied to
 any code you want to test.
 
-However, before it can really be used you need to make it available as a plugin.
+However, before it can really be used, you need to make it available as a plugin.
 
 ### Creating the plugin
 


### PR DESCRIPTION
Also convert some tabs to spaces, and wrap a paragraph.