### PR TITLE
Allow session-name.json to be passed on the command line

### DIFF
--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -99,7 +99,10 @@ options:
 
 
 def _get_db_name(session_name):
-    return '{}.json'.format(session_name)
+    if session_name.endswith('.json'):
+        return session_name
+    else:
+        return '{}.json'.format(session_name)
 
 
 def handle_init(configuration):


### PR DESCRIPTION
This makes it easier to use bash tab completion