### PR TITLE
Report the mutation results using unified diff format

### DIFF
--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -292,8 +292,6 @@ options:
             operator,
             int(config['<occurrence>']),
             test_runner)
-        if result_type == 'exception':
-            data = str(data)
 
     sys.stdout.write(
         json.dumps((result_type, data),

--- a/cosmic_ray/commands/report.py
+++ b/cosmic_ray/commands/report.py
@@ -1,15 +1,23 @@
 def _print_item(item):
-    return [
-        'job ID: {}'.format(item.work_id),
-        'module: {}'.format(item.module_name),
-        'operator: {}'.format(item.operator_name),
-        'occurrence: {}'.format(item.occurrence),
+    result = item.result_data
+    result_type = item.result_type
+    if result_type in ['normal', 'exception']:
+        result_type = result[1][0]
+    ret_val = [
+        'job ID {}:{}:{}'.format(
+            item.work_id,
+            result_type,
+            item.module_name),
         'command: {}'.format(
             ' '.join(item.command)
             if item.command is not None else ''),
-        'result type: {}'.format(item.result_type),
-        'data: {}'.format(item.result_data)
         ]
+    if result_type == 'timeout':
+        ret_val.append("timeout: {:.3f} sec".format(result))
+    elif result_type in ['normal', 'exception']:
+        ret_val += result[1][1]
+
+    return ret_val
 
 
 def _get_kills(db):

--- a/cosmic_ray/testing/test_runner.py
+++ b/cosmic_ray/testing/test_runner.py
@@ -1,6 +1,8 @@
 import abc
 from collections import namedtuple
 from enum import Enum
+import sys
+import traceback
 
 
 class Outcome(Enum):
@@ -64,6 +66,6 @@ class TestRunner(metaclass=abc.ABCMeta):
             else:
                 return TestResult(Outcome.KILLED,
                                   test_result[1])
-        except Exception as e:
+        except Exception:
             return TestResult(Outcome.INCOMPETENT,
-                              str(e))
+                              traceback.format_exception(*sys.exc_info()))

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
     platforms='any',
     include_package_data=True,
     install_requires=[
+        'astunparse',
         'celery',
         'decorator',
         'docopt',


### PR DESCRIPTION
The idea comes from https://github.com/mbj/mutant - the Ruby mutation testing tool. I've tried to emulate their format as much as possible. I've also added the diff output in case there is an exception so it is easier to debug.  NOTE: The ast parser is stripping out comments, newlines and converting double to single quotes and because of this I'm diff'ing the unparsed value of the original and modifies AST trees. This also leads to difference in line numbers, but still should be easier to navigate than the N-th occurrence of operator X.

An example from one of my test executions:

```
job ID 81:Outcome.SURVIVED:pykickstart.commands.autopart
command: cosmic-ray worker pykickstart.commands.autopart replace_Eq_with_IsNot 3 unittest -- tests/
--- mutation diff ---
--- a/home/atodorov/repos/git/pykickstart/pykickstart/commands/autopart.py
+++ b/home/atodorov/repos/git/pykickstart/pykickstart/commands/autopart.py
@@ -268,7 +268,7 @@
         retval = F20_AutoPart.parse(self, args)
         if (self.fstype == 'btrfs'):
             raise KickstartParseError(formatErrorMsg(self.lineno, msg=_('autopart --fstype=btrfs is not valid fstype, use --type=btrfs instead')))
-        if ((self._typeAsStr() == 'btrfs') and self.fstype):
+        if ((self._typeAsStr() is not 'btrfs') and self.fstype):
             raise KickstartParseError(formatErrorMsg(self.lineno, msg=_('autopart --fstype cannot be used with --type=btrfs')))
         return retval
 RHEL7_AutoPart = F21_AutoPart

total jobs: 81
complete: 81 (100.00%)
survival rate: 100.00%
```

I'm not going to colorize the diff output at the moment. There is `colordiff` and other tools which appear to be working decently. In case you are desperate (or crazy) there is also a sed command listed at https://retracile.net/blog/2013/06/01/22.00.

