### PR TITLE
Accept directories and .py files as module names

### DIFF
--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -140,7 +140,7 @@ options:
     LOG.info('timeout = {} seconds'.format(timeout))
 
     modules = set(
-        cosmic_ray.modules.find_modules(
+        cosmic_ray.modules.find_local_modules(
             configuration['<top-module>'],
             configuration['--exclude-modules']))
 
@@ -231,7 +231,7 @@ options:
 """
     sys.path.insert(0, '')
 
-    modules = cosmic_ray.modules.find_modules(
+    modules = cosmic_ray.modules.find_local_modules(
         configuration['<top-module>'],
         configuration['--exclude-modules'])
 

--- a/cosmic_ray/modules.py
+++ b/cosmic_ray/modules.py
@@ -3,11 +3,26 @@
 
 import importlib
 import logging
+import os
 import pkgutil
 import re
 
 LOG = logging.getLogger()
 
+def find_local_modules(name, excludes=None):
+    """
+        Just calls find_modules() but taking into
+        account the fact that name may be a relative or full
+        path to a .py file or directory.
+    """
+    # helps when using bash completion
+    if os.path.exists(name):
+        if name.endswith('.py'):
+            name = name[:-3]
+        name = name.replace('/', '.')
+
+    for module in find_modules(name, excludes):
+        yield module
 
 def find_modules(name, excludes=None):
     """Generate sequence of all submodules of NAME, including NAME itself.

--- a/cosmic_ray/test/test_find_modules.py
+++ b/cosmic_ray/test/test_find_modules.py
@@ -1,6 +1,6 @@
-import contextlib
-import os.path
 from pathlib import Path
+import contextlib
+import os
 import sys
 
 import cosmic_ray.modules
@@ -15,16 +15,20 @@ def extend_path(directory):
     """Put `directory` at the front of `sys.path` temporarily.
     """
     sys.path = [str(directory)] + sys.path
+    old_dir = os.getcwd()
+    os.chdir(str(directory))
     try:
         yield
     finally:
         sys.path = sys.path[1:]
+        os.chdir(old_dir)
 
 
 def test_small_directory_tree():
     datadir = THIS_DIR / 'data'
     paths = (('a', '__init__.py'),
              ('a', 'b.py'),
+             ('a', 'py.py'),
              ('a', 'c', '__init__.py'),
              ('a', 'c', 'd.py'))
     expected = sorted(datadir / Path(*path) for path in paths)
@@ -32,4 +36,57 @@ def test_small_directory_tree():
         results = sorted(
             Path(m.__file__)
             for m in cosmic_ray.modules.find_modules('a'))
+    assert expected == results
+
+def test_finding_modules_via_dir_name():
+    datadir = THIS_DIR / 'data'
+    paths = (('a', 'c', '__init__.py'),
+            ('a', 'c', 'd.py'))
+    expected = sorted(datadir / Path(*path) for path in paths)
+    with extend_path(datadir):
+        results = sorted(
+            Path(m.__file__)
+            for m in cosmic_ray.modules.find_local_modules('a/c'))
+    assert expected == results
+
+def test_finding_modules_via_dir_name_and_filename_ending_in_py():
+    datadir = THIS_DIR / 'data'
+    paths = (('a', 'c', 'd.py'),)
+    expected = sorted(datadir / Path(*path) for path in paths)
+    with extend_path(datadir):
+        results = sorted(
+            Path(m.__file__)
+            for m in cosmic_ray.modules.find_local_modules('a/c/d.py'))
+    assert expected == results
+
+def test_finding_module_py_dot_py_using_dots():
+    datadir = THIS_DIR / 'data'
+    paths = (('a', 'py.py'),)
+    expected = sorted(datadir / Path(*path) for path in paths)
+    with extend_path(datadir):
+        results = sorted(
+            Path(m.__file__)
+            for m in cosmic_ray.modules.find_local_modules('a.py'))
+    # a.py is not a path so we load a/py.py
+    assert expected == results
+
+def test_finding_modules_py_dot_py_using_slashes():
+    datadir = THIS_DIR / 'data'
+    paths = (('a', 'py.py'),)
+    with extend_path(datadir):
+        results = sorted(
+            Path(m.__file__)
+            for m in cosmic_ray.modules.find_local_modules('a/py'))
+    # a/py isn't a directory so nothing is loaded
+    assert [] == results
+
+def test_finding_modules_py_dot_py_using_slashes_with_full_filename():
+    datadir = THIS_DIR / 'data'
+    paths = (('a', 'py.py'),)
+    expected = sorted(datadir / Path(*path) for path in paths)
+    with extend_path(datadir):
+        results = sorted(
+            Path(m.__file__)
+            for m in cosmic_ray.modules.find_local_modules('a/py.py'))
+    # a/py.py is a module and it is loaded
     assert expected == results


### PR DESCRIPTION
This is another minor improvement patch which lets you do things like:

    cosmic-ray init --baseline=10 authconfig pykickstart/commands/authconfig.py -- tests/

I find it very handy b/c I'm using tab-completion all the time.