### PR TITLE
Use Celery's logger for celery tasks

### DIFF
--- a/cosmic_ray/tasks/worker.py
+++ b/cosmic_ray/tasks/worker.py
@@ -3,13 +3,13 @@
 """
 import itertools
 import json
-import logging
 import subprocess
 import celery
 
 from .celery import app
+from celery.utils.log import get_logger
 
-LOG = logging.getLogger()
+LOG = get_logger(__name__)
 
 
 @app.task(name='cosmic_ray.tasks.worker')


### PR DESCRIPTION
This has the nice effect of logging stuff into my celery worker's log so I can monitor progress. On my system I get the following output after `celery -A cosmic_ray.tasks.worker worker` has been started and I run `cosmic-ray execute`
```
[2016-07-07 12:25:13,115: WARNING/Worker-2] executing:
[2016-07-07 12:25:13,115: WARNING/Worker-2] ['cosmic-ray', 'worker', 'pykickstart.commands.autopart', 'replace_Eq_with_NotIn', '0', 'unittest', '--', 'tests/']
[2016-07-07 12:25:13,116: WARNING/Worker-1] executing:
[2016-07-07 12:25:13,117: WARNING/Worker-1] ['cosmic-ray', 'worker', 'pykickstart.commands.autopart', 'replace_Eq_with_NotIn', '1', 'unittest', '--', 'tests/']
[2016-07-07 12:25:13,123: WARNING/Worker-3] executing:
[2016-07-07 12:25:13,123: WARNING/Worker-3] ['cosmic-ray', 'worker', 'pykickstart.commands.autopart', 'replace_Eq_with_NotIn', '2', 'unittest', '--', 'tests/']
```