### PR TITLE
Properly check for result type when reporting

### DIFF
--- a/cosmic_ray/commands/report.py
+++ b/cosmic_ray/commands/report.py
@@ -12,9 +12,9 @@ def _print_item(item):
             ' '.join(item.command)
             if item.command is not None else ''),
         ]
-    if result_type == 'timeout':
+    if item.result_type == 'timeout':
         ret_val.append("timeout: {:.3f} sec".format(result))
-    elif result_type in ['normal', 'exception']:
+    elif item.result_type in ['normal', 'exception']:
         ret_val += result[1][1]
 
     return ret_val


### PR DESCRIPTION
B/c we modify the result_type without this patch the diff output isn't shown.