### PR TITLE
Return a list of strings for unittest results, not list of tuples

### DIFF
--- a/cosmic_ray/testing/unittest_runner.py
+++ b/cosmic_ray/testing/unittest_runner.py
@@ -22,6 +22,4 @@ class UnittestRunner(TestRunner):  # pylint:disable=no-init, too-few-public-meth
 
         return (
             result.wasSuccessful(),
-            [(str(r[0]), r[1])
-             for r in chain(result.errors,
-                            result.failures)])
+            [r[1] for r in chain(result.errors, result.failures)])


### PR DESCRIPTION
This is needed so the reporter can print a nicely formatted traceback when the job is killed.

You can use the Python examples at https://github.com/atodorov/mutation-testing-example to see how results are reported with and w/o this patch. 

Also I'm not sure how the pytest runner will report the failed results and if that wouldn't clash with this existing patch. I don't have a pytest suite ATM but I'll try to make one a give it a try.


