### PR TITLE
Don't show test output and mutation diff if result is KILLED

### DIFF
--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -192,16 +192,20 @@ options:
 
 
 def handle_report(configuration):
-    """usage: cosmic-ray report [--show-pending] <session-name>
+    """usage: cosmic-ray report [--full-kill-report] [--show-pending] <session-name>
 
 Print a nicely formatted report of test results and some basic statistics.
+
+options:
+    --full-report  Show tes output and mutation diff for killed mutants
 
     """
     db_name = _get_db_name(configuration['<session-name>'])
     show_pending = configuration['--show-pending']
+    full_report = configuration['--full-report']
 
     with use_db(db_name, WorkDB.Mode.open) as db:
-        for line in cosmic_ray.commands.create_report(db, show_pending):
+        for line in cosmic_ray.commands.create_report(db, show_pending, full_report):
             print(line)
 
 

--- a/cosmic_ray/commands/report.py
+++ b/cosmic_ray/commands/report.py
@@ -1,4 +1,4 @@
-def _print_item(item):
+def _print_item(item, full_report):
     result = item.result_data
     result_type = item.result_type
     if result_type in ['normal', 'exception']:
@@ -12,7 +12,9 @@ def _print_item(item):
             ' '.join(item.command)
             if item.command is not None else ''),
         ]
-    if item.result_type == 'timeout':
+    if result_type == 'Outcome.KILLED' and not full_report:
+        pass
+    elif item.result_type == 'timeout':
         ret_val.append("timeout: {:.3f} sec".format(result))
     elif item.result_type in ['normal', 'exception']:
         ret_val += result[1][1]
@@ -40,10 +42,10 @@ def _base_stats(work_db):
     return (total_jobs, pending_jobs, completed_jobs, kills)
 
 
-def create_report(work_db, show_pending):
+def create_report(work_db, show_pending, full_report=False):
     for item in work_db.work_items:
         if (item.result_type is not None) or show_pending:
-            yield from _print_item(item)
+            yield from _print_item(item, full_report)
             yield ''
 
     total_jobs, pending_jobs, completed_jobs, kills = _base_stats(work_db)


### PR DESCRIPTION
this makes it possible to keep cleaner output and only reports
diffs for mutations which survived or were incompetent. Use the
--full-report option to show everything if you want.

We can probably extend this to other types of results as well. For now I only want to see the diff for mutants that survived so I can easily spot where I'm missing test cases.

Another possibility is to report only the survived mutants and nothing else. What do you think ?