### PR TITLE
Add Boolean replacer

### DIFF
--- a/cosmic_ray/operators/boolean_replacer.py
+++ b/cosmic_ray/operators/boolean_replacer.py
@@ -1,0 +1,24 @@
+import ast
+
+from .operator import Operator
+
+
+class BooleanReplacer(Operator):
+    """An operator that modifies True/False constants.
+    """
+    def visit_NameConstant(self, node):  # noqa
+        """
+            New in version 3.4: Previously, these constants were instances of ``Name``.
+            http://greentreesnakes.readthedocs.io/en/latest/nodes.html#NameConstant
+        """
+        if node.value in [True, False]:
+            return self.visit_mutation_site(node)
+        else:
+            return node
+
+    def mutate(self, node):
+        """Modify the boolean value on `node`.
+        """
+        new_node = ast.NameConstant(value=not node.value)
+        return new_node
+

--- a/cosmic_ray/test/test_operators.py
+++ b/cosmic_ray/test/test_operators.py
@@ -6,6 +6,7 @@ import pytest
 
 import cosmic_ray.operators.relational_operator_replacement as ROR
 from cosmic_ray.counting import _CountingCore
+from cosmic_ray.operators.boolean_replacer import BooleanReplacer
 from cosmic_ray.operators.break_continue import (ReplaceBreakWithContinue,
                                                  ReplaceContinueWithBreak)
 from cosmic_ray.operators.number_replacer import NumberReplacer
@@ -55,6 +56,7 @@ RELATIONAL_OPERATOR_SAMPLES = [
 ]
 
 OPERATOR_SAMPLES = [
+    (BooleanReplacer, 'True'),
     (ReplaceBreakWithContinue, 'while True: break'),
     (ReplaceContinueWithBreak, 'while False: continue'),
     (NumberReplacer, 'x = 1'),

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,9 @@ operators = [
     'number_replacer = '
     'cosmic_ray.operators.number_replacer:NumberReplacer',
 
+    'boolean_replacer = '
+    'cosmic_ray.operators.boolean_replacer:BooleanReplacer',
+
     'arithmetic_operator_deletion ='
     'cosmic_ray.operators.arithmetic_operator_deletion:ReverseUnarySub',
 

--- a/test_project/adam.py
+++ b/test_project/adam.py
@@ -7,6 +7,13 @@
 def constant_number():
     return 42
 
+def constant_true():
+    return True
+
+
+def constant_false():
+    return False
+
 
 def unary_sub():
     return -1

--- a/test_project/adam.py
+++ b/test_project/adam.py
@@ -47,5 +47,9 @@ def use_continue(limit):
 def trigger_infinite_loop():
     # When `break` becomes `continue`, this should enter an infinite loop. This
     # helps us test timeouts.
-    while True:
+    # Any object which isn't None passes the truth value testing so here
+    # we use `while object()` instead of `while True` b/c the later becomes
+    # `while False` when BooleanReplacer is applied and we don't trigger an
+    # infinite loop.
+    while object():
         break

--- a/test_project/tests/test_adam.py
+++ b/test_project/tests/test_adam.py
@@ -11,6 +11,16 @@ class Tests(unittest.TestCase):
             adam.constant_number(),
             42)
 
+    def test_constant_true(self):
+        self.assertEqual(
+            adam.constant_true(),
+            True)
+
+    def test_constant_false(self):
+        self.assertEqual(
+            adam.constant_false(),
+            False)
+
     def test_unary_sub(self):
         self.assertEqual(
             adam.unary_sub(),


### PR DESCRIPTION
@abingham I've fixed a minor issue with the `--full-report` option which you probably want to cherry-pick.

Next I've enabled reports in CI to see what's going on wrong and added a Boolean replacement operator which simply flips `True` and `False` values.

ATM I'm missing tests in `cosmic_ray/test/test_operators.py` b/c I'm not quite sure what is the format.
Also the adam tests are failing b/c there is a `while True:` loop which becomes `while False`. I can modify the loop somehow so we always trigger an infinite loop and not conflict with the BooleanReplacer operator or maybe you can tell me what other tests to add.