### PR TITLE
Workaround for empty __init__.py files

### DIFF
--- a/cosmic_ray/parsing.py
+++ b/cosmic_ray/parsing.py
@@ -22,15 +22,20 @@ def get_ast(module):
         TypeError: If the source file for `module` can't be found.
     """
     try:
-        source = inspect.getsource(module)
-    except OSError:
-        LOG.warning("Unable to read source for module %s", module)
-        raise
-
-    try:
         source_file = inspect.getsourcefile(module)
     except TypeError:
         LOG.error("Unable to get source file for object %s", module)
         raise
+
+    try:
+        source = inspect.getsource(module)
+    except OSError:
+        # workaround for empty __init__.py files, see
+        # http://bugs.python.org/issue27578
+        if source_file.endswith('__init__.py'):
+            source = ''
+        else:
+            LOG.warning("Unable to read source for module %s", module)
+            raise
 
     return ast.parse(source, source_file, 'exec')

--- a/test_project/cosmic-ray.empty.conf
+++ b/test_project/cosmic-ray.empty.conf
@@ -1,0 +1,9 @@
+# Run the tests against an empty __init__.py file
+--verbose
+run
+--test-runner=unittest
+--baseline=10
+empty.unittest
+empty/__init__.py
+--
+tests

--- a/test_project/run_tests.sh
+++ b/test_project/run_tests.sh
@@ -21,4 +21,10 @@ cosmic-ray load cosmic-ray.nosetest.conf
 RESULT=`cosmic-ray survival-rate adam_tests.nosetest`
 if [ $RESULT != 0.00 ]; then exit 1; fi
 
+cosmic-ray load cosmic-ray.empty.conf
+cosmic-ray report empty.unittest
+#cosmic-ray survival-rate empty.unittest
+RESULT=`cosmic-ray survival-rate empty.unittest`
+if [ $RESULT != 0.00 ]; then exit 1; fi
+
 exit 0


### PR DESCRIPTION
Running against one of my production SUT I was seeing an error similar to this:
https://travis-ci.org/MrSenko/cosmic-ray/jobs/146085309

With the workaround everything seems to work fine:
https://travis-ci.org/MrSenko/cosmic-ray/jobs/146087865

Note the upstream Python bug http://bugs.python.org/issue27578. I doubt it will get fixed or at least not soon enough, hence the need to workaround. 