### PR TITLE
Skip  Eq and Is  replacement

### DIFF
--- a/cosmic_ray/operators/relational_operator_replacement.py
+++ b/cosmic_ray/operators/relational_operator_replacement.py
@@ -23,6 +23,7 @@ RELATIONAL_OPERATORS = {ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE,
 # they almost always produce equivalent mutants. This is a set of
 # (FROM-OP, TO-OP) tuples which we don't want to generate.
 SKIP = {
+    (ast.Eq, ast.Is),
     (ast.NotEq, ast.IsNot),
 }
 


### PR DESCRIPTION
In my experience these two appear to be equivalent and it makes sense to skip this replacement in the same fashion we do for their Not counterparts.

@abingham what do you think ?