### PR TITLE
Added additional python versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: python
-python:
-  - "3.4"
-  - "3.5"
+
+matrix:
+  include:
+    - python: 3.3
+    - python: 3.4
+    - python: 3.5
+    - python: 3.5-dev
+    - python: nightly
+  allow_failures:
+  - python: 3.3
+  fast_finish: true
 
 install: python setup.py install
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import io
 import os
 import re
 from setuptools import setup, find_packages
+import sys
 
 from cosmic_ray.operators.relational_operator_replacement \
     import relational_operator_pairs
@@ -48,6 +49,22 @@ operators = [
     'cosmic_ray.operators.break_continue:ReplaceBreakWithContinue',
 ] + relational_replacement_operators
 
+INSTALL_REQUIRES = [
+    'astunparse',
+    'decorator',
+    'docopt',
+    'pathlib',
+    'pytest',
+    'stevedore',
+    'tinydb',
+    'transducer',
+]
+
+if sys.version_info >= (3,4):
+    INSTALL_REQUIRES.append('celery')
+else:
+    INSTALL_REQUIRES.append('celery<4')
+
 setup(
     name='cosmic_ray',
     version=find_version('cosmic_ray/version.py'),
@@ -73,17 +90,7 @@ setup(
     ],
     platforms='any',
     include_package_data=True,
-    install_requires=[
-        'astunparse',
-        'celery',
-        'decorator',
-        'docopt',
-        'pathlib',
-        'pytest',
-        'stevedore',
-        'tinydb',
-        'transducer',
-    ],
+    install_requires=INSTALL_REQUIRES,
     entry_points={
         'console_scripts': [
             'cosmic-ray = cosmic_ray.cli:main',


### PR DESCRIPTION
Python 3.5, 3.5-dev, and nightly build were added, and the tests pass.
Python 3.3 required a change of version for celery, and is still failing.  But could be salvageable.
Python 3.2 does not support `yield from`, so it is unlikely that it is worth the effort to make this work.