### PR TITLE
Python 3.3 fixes and AND/OR mutation operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,10 @@ language: python
 
 matrix:
   include:
-    - python: 3.3
     - python: 3.4
     - python: 3.5
     - python: 3.5-dev
     - python: nightly
-  allow_failures:
-  - python: 3.3
   fast_finish: true
 
 install: python setup.py install

--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -3,7 +3,6 @@
 Here we manage command-line parsing and launching of the internal
 machinery that does mutation testing.
 """
-from contextlib import redirect_stdout
 import itertools
 import json
 import logging
@@ -24,6 +23,7 @@ import cosmic_ray.json_util
 import cosmic_ray.worker
 import cosmic_ray.testing
 import cosmic_ray.timing
+from cosmic_ray.util import redirect_stdout
 from cosmic_ray.work_db import use_db, WorkDB
 
 

--- a/cosmic_ray/operators/boolean_replacer.py
+++ b/cosmic_ray/operators/boolean_replacer.py
@@ -54,3 +54,52 @@ class ReplaceOrWithAnd(Operator):
     def mutate(self, node):
         """Replace OR with AND."""
         return ast.And()
+
+
+class RemoveNot(Operator):
+
+    """An operator that removes the 'not' keyword from expressions."""
+
+    def visit_UnaryOp(self, node):  # noqa
+        """
+        http://greentreesnakes.readthedocs.io/en/latest/nodes.html#UnaryOp
+        """
+        if isinstance(node.op, ast.Not):
+            return self.visit_mutation_site(node)
+        else:
+            return node
+
+    def mutate(self, node):
+        """Remove the 'not' keyword."""
+        # UnaryOp.operand is any expression node so just
+        # return the expression without the 'not' keyword
+        return node.operand
+
+
+class AddNot(Operator):
+
+    """An operator that adds the 'not' keyword to expressions."""
+
+    def visit_If(self, node):  # noqa
+        return self.visit_mutation_site(node)
+
+    def visit_IfExp(self, node):  # noqa
+        return self.visit_mutation_site(node)
+
+    def visit_Assert(self, node):  # noqa
+        return self.visit_mutation_site(node)
+
+    def visit_While(self, node):  # noqa
+        return self.visit_mutation_site(node)
+
+    def mutate(self, node):
+        """
+        Add the 'not' keyword.
+
+        Note: this will negate the entire if condition.
+        """
+        if hasattr(node, 'test'):
+            node.test = ast.UnaryOp(op=ast.Not(), operand=node.test)
+            # add lineno & col_offset to the nodes we created
+            ast.fix_missing_locations(node)
+            return node

--- a/cosmic_ray/operators/boolean_replacer.py
+++ b/cosmic_ray/operators/boolean_replacer.py
@@ -1,11 +1,10 @@
 import ast
-
+import sys
 from .operator import Operator
 
 
-class BooleanReplacer(Operator):
-    """An operator that modifies True/False constants.
-    """
+class ReplaceTrueFalse(Operator):
+    """An operator that modifies True/False constants."""
     def visit_NameConstant(self, node):  # noqa
         """
             New in version 3.4: Previously, these constants were instances of ``Name``.
@@ -16,9 +15,16 @@ class BooleanReplacer(Operator):
         else:
             return node
 
-    def mutate(self, node):
-        """Modify the boolean value on `node`.
-        """
-        new_node = ast.NameConstant(value=not node.value)
-        return new_node
+    def visit_Name(self, node):  #noqa
+        """For backward compatibility with Python 3.3."""
+        if node.id in ['True', 'False']:
+            return self.visit_mutation_site(node)
+        else:
+            return node
 
+    def mutate(self, node):
+        """Modify the boolean value on `node`."""
+        if sys.version_info >= (3, 4):
+            return ast.NameConstant(value=not node.value)
+        else:
+            return ast.Name(id=not ast.literal_eval(node.id), ctx=node.ctx)

--- a/cosmic_ray/operators/boolean_replacer.py
+++ b/cosmic_ray/operators/boolean_replacer.py
@@ -15,7 +15,7 @@ class ReplaceTrueFalse(Operator):
         else:
             return node
 
-    def visit_Name(self, node):  #noqa
+    def visit_Name(self, node):  # noqa
         """For backward compatibility with Python 3.3."""
         if node.id in ['True', 'False']:
             return self.visit_mutation_site(node)
@@ -28,3 +28,29 @@ class ReplaceTrueFalse(Operator):
             return ast.NameConstant(value=not node.value)
         else:
             return ast.Name(id=not ast.literal_eval(node.id), ctx=node.ctx)
+
+
+class ReplaceAndWithOr(Operator):
+    """An operator that swaps 'and' with 'or'."""
+    def visit_And(self, node):  # noqa
+        """
+            http://greentreesnakes.readthedocs.io/en/latest/nodes.html#And
+        """
+        return self.visit_mutation_site(node)
+
+    def mutate(self, node):
+        """Replace AND with OR."""
+        return ast.Or()
+
+
+class ReplaceOrWithAnd(Operator):
+    """An operator that swaps 'or' with 'and'."""
+    def visit_Or(self, node):  # noqa
+        """
+            http://greentreesnakes.readthedocs.io/en/latest/nodes.html#Or
+        """
+        return self.visit_mutation_site(node)
+
+    def mutate(self, node):
+        """Replace OR with AND."""
+        return ast.And()

--- a/cosmic_ray/test/test_operators.py
+++ b/cosmic_ray/test/test_operators.py
@@ -6,7 +6,9 @@ import pytest
 
 import cosmic_ray.operators.relational_operator_replacement as ROR
 from cosmic_ray.counting import _CountingCore
-from cosmic_ray.operators.boolean_replacer import BooleanReplacer
+from cosmic_ray.operators.boolean_replacer import (ReplaceTrueFalse,
+                                                   ReplaceAndWithOr,
+                                                   ReplaceOrWithAnd)
 from cosmic_ray.operators.break_continue import (ReplaceBreakWithContinue,
                                                  ReplaceContinueWithBreak)
 from cosmic_ray.operators.number_replacer import NumberReplacer
@@ -56,7 +58,9 @@ RELATIONAL_OPERATOR_SAMPLES = [
 ]
 
 OPERATOR_SAMPLES = [
-    (BooleanReplacer, 'True'),
+    (ReplaceTrueFalse, 'True'),
+    (ReplaceAndWithOr, 'if True and False: pass'),
+    (ReplaceOrWithAnd, 'if True or False: pass'),
     (ReplaceBreakWithContinue, 'while True: break'),
     (ReplaceContinueWithBreak, 'while False: continue'),
     (NumberReplacer, 'x = 1'),

--- a/cosmic_ray/test/test_operators.py
+++ b/cosmic_ray/test/test_operators.py
@@ -8,7 +8,8 @@ import cosmic_ray.operators.relational_operator_replacement as ROR
 from cosmic_ray.counting import _CountingCore
 from cosmic_ray.operators.boolean_replacer import (ReplaceTrueFalse,
                                                    ReplaceAndWithOr,
-                                                   ReplaceOrWithAnd)
+                                                   ReplaceOrWithAnd,
+                                                   RemoveNot, AddNot)
 from cosmic_ray.operators.break_continue import (ReplaceBreakWithContinue,
                                                  ReplaceContinueWithBreak)
 from cosmic_ray.operators.number_replacer import NumberReplacer
@@ -61,6 +62,11 @@ OPERATOR_SAMPLES = [
     (ReplaceTrueFalse, 'True'),
     (ReplaceAndWithOr, 'if True and False: pass'),
     (ReplaceOrWithAnd, 'if True or False: pass'),
+    (RemoveNot, 'if not False: pass'),
+    (AddNot, 'if True or False: pass'),
+    (AddNot, 'A if B else C'),
+    (AddNot, 'assert isinstance(node, ast.Break)'),
+    (AddNot, 'while True: pass'),
     (ReplaceBreakWithContinue, 'while True: break'),
     (ReplaceContinueWithBreak, 'while False: continue'),
     (NumberReplacer, 'x = 1'),
@@ -95,7 +101,9 @@ def test_mutation_changes_ast(operator, code):
     orig_nodes = linearize_tree(node)
     mutant_nodes = linearize_tree(mutant)
 
-    assert len(orig_nodes) == len(mutant_nodes)
+#todo: disabled b/c adding/removing the not keyword
+# changes the number of nodes in the tree.
+#    assert len(orig_nodes) == len(mutant_nodes)
 
     assert ast.dump(node) != ast.dump(mutant)
 

--- a/cosmic_ray/testing/nose_runner.py
+++ b/cosmic_ray/testing/nose_runner.py
@@ -1,20 +1,8 @@
-from contextlib import redirect_stdout
-try:
-    from contextlib import redirect_stderr
-except ImportError:
-    # redirect_stderr was introduced in Python 3.5
-    class redirect_stderr(redirect_stdout):
-        """
-            Copied from Python 3.5's implementation. See:
-            https://github.com/python/cpython/commit/83935e76e35cf8d2fb9fe2599420f8adf421b884#diff-edbcdd20abc32f8b018deb2353ae925a
-        """
-
-        _stream = "stderr"
-
-import nose
 import os
+import nose
 
 from .test_runner import TestRunner
+from cosmic_ray.util import redirect_stdout, redirect_stderr
 
 
 class NoseResultsCollector(nose.plugins.Plugin):

--- a/cosmic_ray/testing/pytest_runner.py
+++ b/cosmic_ray/testing/pytest_runner.py
@@ -1,9 +1,8 @@
-from contextlib import redirect_stdout
 import os
-
 import pytest
 
 from .test_runner import TestRunner
+from cosmic_ray.util import redirect_stdout
 
 
 class ResultCollector:

--- a/cosmic_ray/util.py
+++ b/cosmic_ray/util.py
@@ -1,3 +1,47 @@
+try:
+    from contextlib import redirect_stdout
+except ImportError:
+    import sys
+    # redirect_stdout was introduced in Python 3.4
+    class _RedirectStream:
+        """
+            Copied from Python 3.5's implementation. See:
+            https://github.com/python/cpython/commit/83935e76e35cf8d2fb9fe2599420f8adf421b884#diff-edbcdd20abc32f8b018deb2353ae925a
+        """
+        _stream = None
+
+        def __init__(self, new_target):
+            self._new_target = new_target
+            # We use a list of old targets to make this CM re-entrant
+            self._old_targets = []
+
+        def __enter__(self):
+            self._old_targets.append(getattr(sys, self._stream))
+            setattr(sys, self._stream, self._new_target)
+            return self._new_target
+
+        def __exit__(self, exctype, excinst, exctb):
+            setattr(sys, self._stream, self._old_targets.pop())
+
+
+    class redirect_stdout(_RedirectStream):
+        """Context manager for temporarily redirecting stdout to another file."""
+        _stream = "stdout"
+
+
+try:
+    from contextlib import redirect_stderr
+except ImportError:
+    # redirect_stderr was introduced in Python 3.5
+    class redirect_stderr(redirect_stdout):
+        """
+            Copied from Python 3.5's implementation. See:
+            https://github.com/python/cpython/commit/83935e76e35cf8d2fb9fe2599420f8adf421b884#diff-edbcdd20abc32f8b018deb2353ae925a
+        """
+
+        _stream = "stderr"
+
+
 def get_line_number(node):
     """Try to get the line number for `node`.
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ if sys.version_info >= (3,4):
     INSTALL_REQUIRES.append('celery')
 else:
     INSTALL_REQUIRES.append('celery<4')
+    INSTALL_REQUIRES.append('enum34')
 
 setup(
     name='cosmic_ray',

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ operators = [
     'number_replacer = '
     'cosmic_ray.operators.number_replacer:NumberReplacer',
 
-    'boolean_replacer = '
-    'cosmic_ray.operators.boolean_replacer:BooleanReplacer',
+    'replace_true_false = '
+    'cosmic_ray.operators.boolean_replacer:ReplaceTrueFalse',
 
     'arithmetic_operator_deletion ='
     'cosmic_ray.operators.arithmetic_operator_deletion:ReverseUnarySub',

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,12 @@ operators = [
     'replace_or_with_and = '
     'cosmic_ray.operators.boolean_replacer:ReplaceOrWithAnd',
 
+    'remove_not = '
+    'cosmic_ray.operators.boolean_replacer:RemoveNot',
+
+    'add_not = '
+    'cosmic_ray.operators.boolean_replacer:AddNot',
+
     'arithmetic_operator_deletion ='
     'cosmic_ray.operators.arithmetic_operator_deletion:ReverseUnarySub',
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,12 @@ operators = [
     'replace_true_false = '
     'cosmic_ray.operators.boolean_replacer:ReplaceTrueFalse',
 
+    'replace_and_with_or = '
+    'cosmic_ray.operators.boolean_replacer:ReplaceAndWithOr',
+
+    'replace_or_with_and = '
+    'cosmic_ray.operators.boolean_replacer:ReplaceOrWithAnd',
+
     'arithmetic_operator_deletion ='
     'cosmic_ray.operators.arithmetic_operator_deletion:ReverseUnarySub',
 

--- a/test_project/adam.py
+++ b/test_project/adam.py
@@ -15,6 +15,14 @@ def constant_false():
     return False
 
 
+def bool_and():
+    return object() and None
+
+
+def bool_or():
+    return object() or None
+
+
 def unary_sub():
     return -1
 

--- a/test_project/adam.py
+++ b/test_project/adam.py
@@ -49,7 +49,7 @@ def trigger_infinite_loop():
     # helps us test timeouts.
     # Any object which isn't None passes the truth value testing so here
     # we use `while object()` instead of `while True` b/c the later becomes
-    # `while False` when BooleanReplacer is applied and we don't trigger an
+    # `while False` when ReplaceTrueFalse is applied and we don't trigger an
     # infinite loop.
     while object():
         break

--- a/test_project/adam.py
+++ b/test_project/adam.py
@@ -23,6 +23,26 @@ def bool_or():
     return object() or None
 
 
+def bool_expr_with_not():
+    return not object()
+
+
+def bool_if():
+    if object():
+        return True
+
+    raise Exception('bool_if() failed')
+
+
+def if_expression():
+    return True if object() else None
+
+
+def assert_in_func():
+    assert object()
+    return True
+
+
 def unary_sub():
     return -1
 
@@ -53,6 +73,7 @@ def use_continue(limit):
 
 
 def trigger_infinite_loop():
+    result = None
     # When `break` becomes `continue`, this should enter an infinite loop. This
     # helps us test timeouts.
     # Any object which isn't None passes the truth value testing so here
@@ -60,4 +81,9 @@ def trigger_infinite_loop():
     # `while False` when ReplaceTrueFalse is applied and we don't trigger an
     # infinite loop.
     while object():
+        result = object()
         break
+
+    # when `while object()` becomes `while not object()`
+    # the code below will be triggered
+    return result

--- a/test_project/run_tests.sh
+++ b/test_project/run_tests.sh
@@ -5,8 +5,6 @@ set -e
 
 cosmic-ray load cosmic-ray.unittest.conf
 if [ $? != 0 ]; then exit 1; fi
-#cosmic-ray report adam_tests.unittest
-#cosmic-ray survival-rate adam_tests.unittest
 RESULT=`cosmic-ray survival-rate adam_tests.unittest`
 if [ $RESULT != 0.00 ]; then
     cosmic-ray report adam_tests.unittest
@@ -15,24 +13,28 @@ fi
 
 cosmic-ray load cosmic-ray.pytest.conf
 if [ $? != 0 ]; then exit 1; fi
-#cosmic-ray report adam_tests.pytest
-#cosmic-ray survival-rate adam_tests.pytest
 RESULT=`cosmic-ray survival-rate adam_tests.pytest`
-if [ $RESULT != 0.00 ]; then exit 1; fi
+if [ $RESULT != 0.00 ]; then
+    cosmic-ray report adam_tests.pytest
+    exit 1
+fi
 
 cosmic-ray load cosmic-ray.nosetest.conf
 if [ $? != 0 ]; then exit 1; fi
-#cosmic-ray report adam_tests.nosetest
-#cosmic-ray survival-rate adam_tests.nosetest
 RESULT=`cosmic-ray survival-rate adam_tests.nosetest`
-if [ $RESULT != 0.00 ]; then exit 1; fi
+if [ $RESULT != 0.00 ]; then
+    cosmic-ray report adam_tests.nosetest
+    exit 1
+fi
 
 # Run import tests
 cosmic-ray load cosmic-ray.import.conf
 if [ $? != 0 ]; then exit 1; fi
-#cosmic-ray report import_tests
-#cosmic-ray survival-rate import_tests
 RESULT=`cosmic-ray survival-rate import_tests`
-if [ $RESULT != 0.00 ]; then exit 1; fi
+if [ $RESULT != 0.00 ]; then
+    cosmic-ray report import_tests
+    exit 1
+fi
+
 
 exit 0

--- a/test_project/run_tests.sh
+++ b/test_project/run_tests.sh
@@ -8,7 +8,10 @@ if [ $? != 0 ]; then exit 1; fi
 #cosmic-ray report adam_tests.unittest
 #cosmic-ray survival-rate adam_tests.unittest
 RESULT=`cosmic-ray survival-rate adam_tests.unittest`
-if [ $RESULT != 0.00 ]; then exit 1; fi
+if [ $RESULT != 0.00 ]; then
+    cosmic-ray report adam_tests.unittest
+    exit 1
+fi
 
 cosmic-ray load cosmic-ray.pytest.conf
 if [ $? != 0 ]; then exit 1; fi

--- a/test_project/tests/test_adam.py
+++ b/test_project/tests/test_adam.py
@@ -27,6 +27,18 @@ class Tests(unittest.TestCase):
     def test_bool_or(self):
         self.assertTrue(adam.bool_or())
 
+    def test_bool_expr_with_not(self):
+        self.assertFalse(adam.bool_expr_with_not())
+
+    def test_bool_if(self):
+        self.assertTrue(adam.bool_if())
+
+    def test_if_expression(self):
+        self.assertTrue(adam.if_expression())
+
+    def test_assert_in_func(self):
+        self.assertTrue(adam.assert_in_func())
+
     def test_unary_sub(self):
         self.assertEqual(
             adam.unary_sub(),
@@ -55,4 +67,4 @@ class Tests(unittest.TestCase):
             9)
 
     def test_trigger_infinite_loop(self):
-        adam.trigger_infinite_loop()
+        self.assertTrue(adam.trigger_infinite_loop())

--- a/test_project/tests/test_adam.py
+++ b/test_project/tests/test_adam.py
@@ -21,6 +21,12 @@ class Tests(unittest.TestCase):
             adam.constant_false(),
             False)
 
+    def test_bool_and(self):
+        self.assertFalse(adam.bool_and())
+
+    def test_bool_or(self):
+        self.assertTrue(adam.bool_or())
+
     def test_unary_sub(self):
         self.assertEqual(
             adam.unary_sub(),


### PR DESCRIPTION
I am submitting these as one PR because I've set out to make the BoolConstReplacer operator 3.3 compatible and then run into some issues.

From #163 

> Python 3.3 required a change of version for celery, and is still failing. But could be salvageable.

@abingham, @degustaf - in `cosmic_ray/importing.py` we make use of `importlib.machinery.ModuleSpec` which was introduced in 3.4. I don't think we can/want to backport this to 3.3 so maybe drop the entire 3.3 compatibility mode ? What do you say ?

@abingham - do you have any preference if I should drop my 3.3 related commits since they will be kind of pointless if we drop this version entirely ? 

