### PR TITLE
Fix a traceback with Python 3.4 and nose

### DIFF
--- a/test_project/cosmic-ray.nosetest.conf
+++ b/test_project/cosmic-ray.nosetest.conf
@@ -7,4 +7,4 @@ adam_tests.nosetest
 adam
 --
 -v
-tests/*.py
+tests/


### PR DESCRIPTION
See https://travis-ci.org/sixty-north/cosmic-ray/jobs/159425168 for the actual traceback. I will open an issue report for the fact that we're not returning a non 0 exit code in this case. As a side note almost none of the command handlers appear to be returning error codes which is expected by main(). 

The fix isn't ideal. Because we're running the test suite in verbose mode logs from the baseline execution and all mutations are logged in Travis. With Python 3.5 this is different and I don't see that much logs in verbose mode.
