### PR TITLE
Prevent modifying session.json when doing cosmic-ray report

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ INSTALL_REQUIRES = [
     'pathlib',
     'pytest',
     'stevedore',
-    'tinydb',
+    'tinydb>=3.2.1',
     'transducer',
 ]
 


### PR DESCRIPTION
this is fixed by requiring TinyDB >= 3.2.1. The particular commit
appears to be https://github.com/msiemens/tinydb/commit/331bb0.

@msiemens would know for sure b/c this is not mentioned in their changelog and the changelog got a bit messed up in the last version.