### PR TITLE
Update mutations for binary operators

### DIFF
--- a/cosmic_ray/operators/binary_operator_replacement.py
+++ b/cosmic_ray/operators/binary_operator_replacement.py
@@ -1,0 +1,44 @@
+import ast
+import sys
+
+from .operator import Operator
+from ..util import build_mutations
+
+
+OPERATORS = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.FloorDiv, ast.Mod,
+             ast.Pow, ast.LShift, ast.RShift, ast.BitOr, ast.BitXor,
+             ast.BitAnd)
+
+# todo: this often leads to unsupported syntax
+#if sys.version_info >= (3, 5):
+#    OPERATORS = OPERATORS + (ast.MatMult, )
+
+
+def _to_ops(from_op):
+    """
+        The sequence of operators which `from_op` could be mutated to.
+    """
+
+    for to_op in OPERATORS:
+        if to_op and isinstance(from_op, to_op):
+            # skip replacement with self
+            pass
+        else:
+            yield to_op
+
+
+class MutateBinaryOperator(Operator):
+    """An operator that modifies binary operators."""
+
+    def visit_BinOp(self, node):
+        """
+            http://greentreesnakes.readthedocs.io/en/latest/nodes.html#BinOp
+        """
+        return self.visit_mutation_site(
+            node,
+            len(build_mutations([node.op], _to_ops)))
+
+    def mutate(self, node, idx):
+        _, to_op = build_mutations([node.op], _to_ops)[idx]
+        node.op = to_op()
+        return node

--- a/cosmic_ray/operators/unary_operator_replacement.py
+++ b/cosmic_ray/operators/unary_operator_replacement.py
@@ -27,7 +27,7 @@ def _to_ops(from_op):
 
 
 class MutateUnaryOperator(Operator):
-    """An operator that modifies comparisons."""
+    """An operator that modifies unary operators."""
 
     def visit_UnaryOp(self, node):
         """

--- a/cosmic_ray/test/test_operators.py
+++ b/cosmic_ray/test/test_operators.py
@@ -8,6 +8,8 @@ from cosmic_ray.operators.comparison_operator_replacement import \
     MutateComparisonOperator
 from cosmic_ray.operators.unary_operator_replacement import \
     MutateUnaryOperator
+from cosmic_ray.operators.binary_operator_replacement import \
+    MutateBinaryOperator
 from cosmic_ray.counting import _CountingCore
 from cosmic_ray.operators.boolean_replacer import (ReplaceTrueFalse,
                                                    ReplaceAndWithOr,
@@ -58,6 +60,8 @@ OPERATOR_SAMPLES = [
     (MutateComparisonOperator, 'if x > y: pass'),
     (MutateUnaryOperator, 'return not X'),
     (MutateUnaryOperator, 'x = -1'),
+    (MutateBinaryOperator, 'x * y'),
+    (MutateBinaryOperator, 'x - y'),
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ INSTALL_REQUIRES = [
     'docopt',
     'nose',
     'pathlib',
-    'pytest',
+    'pytest>=3.0',
     'stevedore',
     'tinydb>=3.2.1',
     'transducer',

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,9 @@ operators = [
     'mutate_unary_operator ='
     'cosmic_ray.operators.unary_operator_replacement:MutateUnaryOperator',
 
+    'mutate_binary_operator ='
+    'cosmic_ray.operators.binary_operator_replacement:MutateBinaryOperator',
+
     'break_continue_replacement ='
     'cosmic_ray.operators.break_continue:ReplaceBreakWithContinue',
 ]

--- a/test_project/adam.py
+++ b/test_project/adam.py
@@ -51,6 +51,9 @@ def unary_add():
     return +1
 
 
+def binary_add():
+    return 5 + 6
+
 def equals(vals):
     def constraint(x, y):
         return (x == y) ^ (x != y)

--- a/test_project/adam.py
+++ b/test_project/adam.py
@@ -3,6 +3,7 @@
 # kill every mutant when that suite is run; if it doesn't, then we've
 # got a problem.
 
+import operator
 
 def constant_number():
     return 42
@@ -56,7 +57,7 @@ def binary_add():
 
 def equals(vals):
     def constraint(x, y):
-        return (x == y) ^ (x != y)
+        return operator.xor(x == y, x != y)
 
     return all([constraint(x, y)
                 for x in vals

--- a/test_project/tests/test_adam.py
+++ b/test_project/tests/test_adam.py
@@ -49,6 +49,9 @@ class Tests(unittest.TestCase):
             adam.unary_add(),
             +1)
 
+    def test_binary_add(self):
+        self.assertEqual(adam.binary_add(), 11)
+
     def test_equals(self):
         vals = [uuid.uuid1(),
                 uuid.uuid1()]


### PR DESCRIPTION
@abingham my previous PR removed all binary operator mutations and this one adds them again. This time we make use of the refactored core and add a lot more possible mutations. Also notice the quick fix of the test suite. The xor in `equals` produces equivalent mutations when replaced with '+' or '-' in this context.