### PR TITLE
Refactor skipping mutations to self

### DIFF
--- a/cosmic_ray/operators/binary_operator_replacement.py
+++ b/cosmic_ray/operators/binary_operator_replacement.py
@@ -10,21 +10,16 @@ OPERATORS = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.FloorDiv, ast.Mod,
              ast.BitAnd)
 
 # todo: this often leads to unsupported syntax
-#if sys.version_info >= (3, 5):
-#    OPERATORS = OPERATORS + (ast.MatMult, )
+if sys.version_info >= (3, 5):
+    OPERATORS = OPERATORS + (ast.MatMult, )
 
 
 def _to_ops(from_op):
     """
         The sequence of operators which `from_op` could be mutated to.
     """
-
     for to_op in OPERATORS:
-        if to_op and isinstance(from_op, to_op):
-            # skip replacement with self
-            pass
-        else:
-            yield to_op
+        yield to_op
 
 
 class MutateBinaryOperator(Operator):

--- a/cosmic_ray/operators/comparison_operator_replacement.py
+++ b/cosmic_ray/operators/comparison_operator_replacement.py
@@ -30,9 +30,7 @@ def _to_ops(from_op):
     """
 
     for to_op in OPERATORS:
-        if isinstance(from_op, to_op):
-            pass
-        elif isinstance(from_op, ast.Eq) and to_op is ast.Is:
+        if isinstance(from_op, ast.Eq) and to_op is ast.Is:
             pass
         elif isinstance(from_op, ast.NotEq) and to_op is ast.IsNot:
             pass

--- a/cosmic_ray/operators/unary_operator_replacement.py
+++ b/cosmic_ray/operators/unary_operator_replacement.py
@@ -12,10 +12,7 @@ def _to_ops(from_op):
     """
 
     for to_op in OPERATORS:
-        if to_op and isinstance(from_op, to_op):
-            # skip replacement with self
-            pass
-        elif to_op and isinstance(from_op, ast.Not):
+        if to_op and isinstance(from_op, ast.Not):
             # 'not' can only be removed but not replaced with
             # '+', '-' or '~' b/c that may lead to strange results
             pass

--- a/cosmic_ray/util.py
+++ b/cosmic_ray/util.py
@@ -64,5 +64,18 @@ def build_mutations(ops, to_ops):
     return [
         (idx, to_op)
         for idx, from_op in enumerate(ops)
-        for to_op in to_ops(from_op)
+        # note: mutations to self are excluded.
+        # None is a special mutation meaning to delete the operator!
+        # 1) when to_op is None isinstance(from_op, None) will blow up because
+        #    the second parameter needs to be a class
+        # 2) when to_op != None we do the isinstance() check to figure out
+        #    whether or not to include the operator in the list of possible mutations
+        #
+        # The `if to_op is None or isinstance(from_op, to_op)` expression handles both
+        # scenarios very elegantly. First we handle 1) and if this is True the rest of
+        # the expression is not evaluated and None is returned. Else we're in scenario 2)
+        # where the left part of the expression is False so the right part is evaluated.
+        # Since the left part of the expression has confirmed that to_op != None then
+        # we're confident that the isinstance() method will always work.
+        for to_op in to_ops(from_op) if to_op is None or not isinstance(from_op, to_op)
     ]


### PR DESCRIPTION
This is now handled in `build_mutations()` because it is a common operation. `_to_ops()` needs to only special case mutations depending on context, e.g. ==/is mutation.

@abingham please review