### PR TITLE
Fail if baseline execution fails

### DIFF
--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -22,7 +22,7 @@ import cosmic_ray.modules
 import cosmic_ray.json_util
 import cosmic_ray.worker
 import cosmic_ray.testing
-import cosmic_ray.timing
+from cosmic_ray.timing import Timer
 from cosmic_ray.util import redirect_stdout
 from cosmic_ray.work_db import use_db, WorkDB
 
@@ -133,10 +133,9 @@ options:
     else:
         baseline_mult = float(configuration['--baseline'])
         assert baseline_mult is not None
-        timeout = baseline_mult * cosmic_ray.timing.run_baseline(
-            configuration['--test-runner'],
-            configuration['<top-module>'],
-            configuration['<test-args>'])
+        with Timer() as t:
+            handle_baseline(configuration)
+        timeout = baseline_mult * t.elapsed.total_seconds()
 
     LOG.info('timeout = %f seconds', timeout)
 

--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -21,10 +21,10 @@ import cosmic_ray.counting
 import cosmic_ray.modules
 import cosmic_ray.json_util
 import cosmic_ray.worker
-import cosmic_ray.testing
 from cosmic_ray.timing import Timer
 from cosmic_ray.util import redirect_stdout
 from cosmic_ray.work_db import use_db, WorkDB
+from cosmic_ray.testing.test_runner import Outcome
 
 
 LOG = logging.getLogger()
@@ -96,7 +96,19 @@ options:
         configuration['<test-args>']
     )
 
-    test_runner()
+    result = test_runner()
+    # note: test_runner() results are meant to represent
+    # status codes when executed against mutants.
+    # SURVIVED means that the test suite executed without any error
+    # hence CR thinks the mutant survived. However when running the
+    # baseline execution we don't have mutations and really want the
+    # test suite to report PASS, hence the comparison below!
+    if result[0] != Outcome.SURVIVED:
+        # baseline failed, print whatever was returned
+        # from the test runner and exit
+        print(''.join(result[1]))
+        LOG.info('baseline failed')
+        sys.exit(2)
 
 
 def _get_db_name(session_name):

--- a/cosmic_ray/timing.py
+++ b/cosmic_ray/timing.py
@@ -5,8 +5,6 @@ generic functionality.
 """
 
 import datetime
-import itertools
-import subprocess
 
 
 class Timer:
@@ -39,18 +37,3 @@ class Timer:
 
     def __exit__(self, ex_type, ex_value, ex_traceback):
         pass
-
-
-def run_baseline(test_runner, module_name, test_args):
-    command = list(itertools.chain(
-        ('cosmic-ray',
-         'baseline',
-         '--test-runner={}'.format(test_runner),
-         module_name,
-         '--',),
-        test_args))
-
-    with Timer() as t:
-        subprocess.call(command)
-
-    return t.elapsed.total_seconds()

--- a/test_project/baseline_fail/test_fail.py
+++ b/test_project/baseline_fail/test_fail.py
@@ -1,0 +1,11 @@
+import unittest
+
+from eve import eve
+
+
+class Tests(unittest.TestCase):
+    def test_constant_42(self):
+        # NOTE: this should always fail b/c we need to verify
+        # that Cosmic Ray exits with non zero when baseline fails!
+        # see https://github.com/sixty-north/cosmic-ray/issues/111
+        self.assertEqual(eve.constant_42(), 0)

--- a/test_project/cosmic-ray.baseline_fail.conf
+++ b/test_project/cosmic-ray.baseline_fail.conf
@@ -1,0 +1,8 @@
+--verbose
+run
+--test-runner=unittest
+--baseline=10
+baseline_fail
+eve/eve.py
+--
+baseline_fail

--- a/test_project/run_tests.sh
+++ b/test_project/run_tests.sh
@@ -1,8 +1,6 @@
 # This runs the "adam" tests, returning 0 if all mutants are killed, or 1 if
 # there's a survivor.
 
-set -e
-
 cosmic-ray load cosmic-ray.unittest.conf
 if [ $? != 0 ]; then exit 1; fi
 RESULT=`cosmic-ray survival-rate adam_tests.unittest`
@@ -42,6 +40,13 @@ if [ $? != 0 ]; then exit 1; fi
 RESULT=`cosmic-ray survival-rate empty.unittest`
 if [ $RESULT != 0.00 ]; then
     cosmic-ray report empty.unittest
+    exit 1
+fi
+
+# Run failing baseline tests
+cosmic-ray load cosmic-ray.baseline_fail.conf
+if [ $? != 2 ]; then
+    echo "baseline didn't fail"
     exit 1
 fi
 

--- a/test_project/run_tests.sh
+++ b/test_project/run_tests.sh
@@ -36,5 +36,13 @@ if [ $RESULT != 0.00 ]; then
     exit 1
 fi
 
+# Run tests for empty __init__.py
+cosmic-ray load cosmic-ray.empty.conf
+if [ $? != 0 ]; then exit 1; fi
+RESULT=`cosmic-ray survival-rate empty.unittest`
+if [ $RESULT != 0.00 ]; then
+    cosmic-ray report empty.unittest
+    exit 1
+fi
 
 exit 0


### PR DESCRIPTION
@abingham this is ready for review.

Please note the first commit in this PR. For some reason I was missing the `run_tests.sh` plumbing from #160 so I did cherry-pick of 2718e81 and adjusted for latest syntax. If you can figure out what went wrong I will be interested to hear, especially if you manage to find steps to reproduce. The only thing that comes to mind is accidentally removing this piece of code while dealing with merge conflicts on Jul 24, 2016.