### PR TITLE
Local execution mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ processes they spawn - need to be able to import the modules you want to test.
 As a result, you generally want to start them in the virtual environment into
 which you've installed Cosmic Ray.
 
+Also remember that the workers need to be able to find and execute the tests as
+expressed to the `init` command. In other words, if you used `cosmic-ray init .
+. . -- tests` to initialize a session, the test loader (whether local or
+distributed) will look for tests in the `test` directory. So you need to make
+sure that the worker processes are running in directory where this makes sense.
+
 Finally, once the worker(s) are running you need to use the `--dist` flag when
 you run `cosmic-ray exec`:
 ```

--- a/README.md
+++ b/README.md
@@ -114,6 +114,6 @@ cosmic-ray exec --dist
 ```
 
 Note that all of the other Cosmic Ray commands --- `init`, `report`, etc. ---
-don't need the `--dist` flag; only `exec` uses it.
+don't need the `--dist` flag; only `exec` and `run` use it.
 
 **[Further documentation is available at readthedocs](http://cosmic-ray.readthedocs.org/en/latest/).**

--- a/README.md
+++ b/README.md
@@ -40,28 +40,9 @@ python setup.py install
 We recommend installing it into a virtual environment. Often it makes sense to
 install it into the virtual environment of the package you want to test.
 
-### Install RabbitMQ and start a worker
-
-Next you need to install [RabbitMQ](https://www.rabbitmq.com/). Cosmic Ray uses
-this message queue (via [Celery](http://www.celeryproject.org/)) to distribute
-testing tasks. Once installed, start the server. This is very platform-specific,
-so see the instructions for RabbitMQ on how to do this.
-
-Once RabbitMQ is running, you need to start one or more Cosmic Ray worker tasks
-to listen for commmands on the queue. Start a worker like this:
-
-```
-celery -A cosmic_ray.tasks.worker worker
-```
-
-You can start as many workers as you want. Be aware that these workers - and the
-processes they spawn - need to be able to import the modules you want to test.
-As a result, you generally want to start them in the virtual environment into
-which you've installed Cosmic Ray.
-
 ### Create a session and run tests
 
-Finally, you're ready to start killing mutants. Cosmic Ray uses a notion of
+Now you're ready to start killing mutants. Cosmic Ray uses a notion of
 *sessions* to encompass a full mutation testing suite. Since mutation testing
 runs can take a long time, and since you might need to stop and start them,
 sessions store data about the progress of a run. The first step in a full
@@ -92,5 +73,41 @@ cosmic-ray report <session name>
 This will print out a bunch of information about the work that was performed,
 including what kinds of mutants were created, which were killed, and
 – chillingly – which survived.
+
+## Distributed testing with Celery
+
+By default Cosmic Ray does all of its testing locally and serially, running only
+one test suite at a time. This can be too slow for many real-world testing
+scenarios. To help speed things up, Cosmic Ray supports distributed mutation
+testing using [Celery](http://www.celeryproject.org/) to send work to more than
+one machine. This is more complex to set up, but it makes mutation testing
+practical for a wider range of projects.
+
+To run Cosmic Ray in distributed mode, you first need to
+install [RabbitMQ](https://www.rabbitmq.com/). Cosmic Ray uses this message
+queue (via Celery) to distribute testing tasks. Once installed, start the
+RabbitMQ server. This is very platform-specific, so see the instructions for
+RabbitMQ on how to do this.
+
+Once RabbitMQ is running, you need to start one or more Cosmic Ray worker tasks
+to listen for commmands on the queue. Start a worker like this:
+
+```
+celery -A cosmic_ray.tasks.worker worker
+```
+
+You can start as many workers as you want. Be aware that these workers - and the
+processes they spawn - need to be able to import the modules you want to test.
+As a result, you generally want to start them in the virtual environment into
+which you've installed Cosmic Ray.
+
+Finally, once the worker(s) are running you need to use the `--dist` flag when
+you run `cosmic-ray exec`:
+```
+cosmic-ray exec --dist
+```
+
+Note that all of the other Cosmic Ray commands --- `init`, `report`, etc. ---
+don't need the `--dist` flag; only `exec` uses it.
 
 **[Further documentation is available at readthedocs](http://cosmic-ray.readthedocs.org/en/latest/).**

--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -187,7 +187,7 @@ options:
 
 
 def handle_run(configuration):
-    """usage: cosmic-ray run [options] [--exclude-modules=P ...] (--timeout=T | --baseline=M) <session-name> <top-module> [-- <test-args> ...]
+    """usage: cosmic-ray run [options] [--dist] [--exclude-modules=P ...] (--timeout=T | --baseline=M) <session-name> <top-module> [-- <test-args> ...]
 
 This simply runs the "init" command followed by the "exec" command.
 

--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -170,29 +170,20 @@ options:
 
 
 def handle_exec(configuration):
-    """usage: cosmic-ray exec <session-name>
+    """usage: cosmic-ray exec [--dist] <session-name>
 
 Perform the remaining work to be done in the specified session. This requires
 that the rest of your mutation testing infrastructure (e.g. worker processes)
 are already running.
 
+options:
+    --dist  Distribute tests to remote workers
     """
     db_name = _get_db_name(configuration['<session-name>'])
+    dist = configuration['--dist']
 
     with use_db(db_name, mode=WorkDB.Mode.open) as db:
-        cosmic_ray.commands.execute(db)
-
-
-def handle_local_exec(configuration):
-    """usage: cosmic-ray local-exec <session-name>
-
-Perform the remaining work to be done in the specified session. This runs all
-of the tests on the local machine and doesn't require any extra infrastructure.
-    """
-    db_name = _get_db_name(configuration['<session-name>'])
-
-    with use_db(db_name, mode=WorkDB.Mode.open) as db:
-        cosmic_ray.commands.local_execute(db)
+        cosmic_ray.commands.execute(db, dist)
 
 
 def handle_run(configuration):
@@ -331,7 +322,6 @@ COMMAND_HANDLER_MAP = {
     'baseline':      handle_baseline,
     'counts':        handle_counts,
     'exec':          handle_exec,
-    'local-exec':    handle_local_exec,
     'help':          handle_help,
     'init':          handle_init,
     'load':          handle_load,

--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -183,6 +183,18 @@ are already running.
         cosmic_ray.commands.execute(db)
 
 
+def handle_local_exec(configuration):
+    """usage: cosmic-ray local-exec <session-name>
+
+Perform the remaining work to be done in the specified session. This runs all
+of the tests on the local machine and doesn't require any extra infrastructure.
+    """
+    db_name = _get_db_name(configuration['<session-name>'])
+
+    with use_db(db_name, mode=WorkDB.Mode.open) as db:
+        cosmic_ray.commands.local_execute(db)
+
+
 def handle_run(configuration):
     """usage: cosmic-ray run [options] [--exclude-modules=P ...] (--timeout=T | --baseline=M) <session-name> <top-module> [-- <test-args> ...]
 
@@ -319,6 +331,7 @@ COMMAND_HANDLER_MAP = {
     'baseline':      handle_baseline,
     'counts':        handle_counts,
     'exec':          handle_exec,
+    'local-exec':    handle_local_exec,
     'help':          handle_help,
     'init':          handle_init,
     'load':          handle_load,

--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -106,8 +106,8 @@ options:
     if result[0] != Outcome.SURVIVED:
         # baseline failed, print whatever was returned
         # from the test runner and exit
+        LOG.error('baseline failed')
         print(''.join(result[1]))
-        LOG.info('baseline failed')
         sys.exit(2)
 
 

--- a/cosmic_ray/commands/__init__.py
+++ b/cosmic_ray/commands/__init__.py
@@ -5,6 +5,6 @@ Not all commands are represented here, just the ones which seem big enough to
 justify a separate module.
 """
 
-from .execute import execute, local_execute
+from .execute import execute
 from .init import init
 from .report import create_report, survival_rate

--- a/cosmic_ray/commands/__init__.py
+++ b/cosmic_ray/commands/__init__.py
@@ -5,6 +5,6 @@ Not all commands are represented here, just the ones which seem big enough to
 justify a separate module.
 """
 
-from .execute import execute
+from .execute import execute, local_execute
 from .init import init
 from .report import create_report, survival_rate

--- a/cosmic_ray/commands/execute.py
+++ b/cosmic_ray/commands/execute.py
@@ -1,33 +1,11 @@
 import cosmic_ray.tasks.celery
 import cosmic_ray.tasks.worker
 
+# TODO: These should be put into plugins. Callers of execute() should pass an
+# executor.
 
-def execute(work_db, purge_queue=True):
-    """Execute any pending work in `work_db`, recording the results.
-
-    This looks for any work in `work_db` which has no results, schedules to be
-    executed, and records any results that arrive.
-
-    """
-    test_runner, test_args, timeout = work_db.get_work_parameters()
-    try:
-        results = cosmic_ray.tasks.worker.execute_work_items(
-            test_runner,
-            test_args,
-            timeout,
-            work_db.pending_work)
-
-        for r in results:
-            job_id, command, (result_type, result_data) = r.get()
-            work_db.add_results(job_id, command, result_type, result_data)
-    finally:
-        if purge_queue:
-            cosmic_ray.tasks.celery.app.control.purge()
-
-
-def local_execute(work_db):
-    test_runner, test_args, timeout = work_db.get_work_parameters()
-    for work_item in work_db.pending_work:
+def local_executor(test_runner, test_args, timeout, pending_work):
+    for work_item in pending_work:
         result = cosmic_ray.tasks.worker.worker_task(
             work_item.work_id,
             work_item.module_name,
@@ -37,4 +15,45 @@ def local_execute(work_db):
             test_args,
             timeout)
         job_id, command, (result_type, result_data) = result
-        work_db.add_results(job_id, command, result_type, result_data)
+        yield job_id, command, result_type, result_data
+
+
+class CeleryExecutor:
+    def __init__(self, purge_queue=True):
+        self.purge_queue = purge_queue
+
+    def __call__(self, test_runner, test_args, timeout, pending_work):
+        try:
+            results = cosmic_ray.tasks.worker.execute_work_items(
+                test_runner,
+                test_args,
+                timeout,
+                pending_work)
+
+            for r in results:
+                job_id, command, (result_type, result_data) = r.get()
+                yield job_id, command, result_type, result_data
+        finally:
+            if self.purge_queue:
+                cosmic_ray.tasks.celery.app.control.purge()
+
+
+def execute(work_db, dist=True):
+    """Execute any pending work in `work_db`, recording the results.
+
+    This looks for any work in `work_db` which has no results, schedules to be
+    executed, and records any results that arrive.
+
+    If `dist` is `True` then this uses Celery to distribute tasks to remote
+    workers; of course you need to make sure that these are running if you want
+    tests to actually run! If `dist` is `False` then all tests will be run
+    locally.
+    """
+    test_runner, test_args, timeout = work_db.get_work_parameters()
+    executor = CeleryExecutor() if dist else local_executor
+    results = executor(test_runner,
+                       test_args,
+                       timeout,
+                       work_db.pending_work)
+    for result in results:
+        work_db.add_results(*result)

--- a/cosmic_ray/commands/execute.py
+++ b/cosmic_ray/commands/execute.py
@@ -23,3 +23,18 @@ def execute(work_db, purge_queue=True):
     finally:
         if purge_queue:
             cosmic_ray.tasks.celery.app.control.purge()
+
+
+def local_execute(work_db):
+    test_runner, test_args, timeout = work_db.get_work_parameters()
+    for work_item in work_db.pending_work:
+        result = cosmic_ray.tasks.worker.worker_task(
+            work_item.work_id,
+            work_item.module_name,
+            work_item.operator_name,
+            work_item.occurrence,
+            test_runner,
+            test_args,
+            timeout)
+        job_id, command, (result_type, result_data) = result
+        work_db.add_results(job_id, command, result_type, result_data)

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,23 @@ This will print out a bunch of information about what Cosmic Ray did, including
 what kinds of mutants were created, which were killed, and –
 chillingly – which survived.
 
+### A concrete example: running the `adam` unittests
+
+Cosmic Ray includes a number of unit tests which perform mutations against a
+simple module called `adam`. As a way of test driving Cosmic Ray, you can run
+these tests, too, like this:
+
+```
+cd test_project
+cosmic-ray init --baseline=10 example-session adam -- tests
+cosmic-ray --verbose exec example-session
+cosmic-ray report example-session
+```
+
+In this case we're passing the `--verbose` flag to the `exec` command so that
+you can see what Cosmic Ray is doing. If everything goes as expected, the
+`report` command will report a 0% survival rate.
+
 ## Installation
 
 You can install Cosmic Ray using `pip`:

--- a/docs/index.md
+++ b/docs/index.md
@@ -134,8 +134,8 @@ The best way to avoid this problem is to keep your test code in separate modules
 from your production code. This way you can tell Cosmic Ray precisely what to
 mutate.
 
-Ideally, your test code will be in a different package form your production
-test. This way you can tell Cosmic Ray to mutate an entire package without
+Ideally, your test code will be in a different package from your production
+code. This way you can tell Cosmic Ray to mutate an entire package without
 needing to filter anything out. However, if your test code is in the same
 package as your production code (a common configuration), you can use the
 `--exclude-modules` flag of `cosmic-ray init` to prevent mutation of your tests.

--- a/test_project/cosmic-ray.nosetest.dist.conf
+++ b/test_project/cosmic-ray.nosetest.dist.conf
@@ -1,9 +1,10 @@
 # Run the adam tests with nose
 --verbose
 run
+--dist
 --test-runner=nose
 --baseline=10
-adam_tests.nosetest
+adam_tests.nosetest.dist
 adam
 --
 -v

--- a/test_project/cosmic-ray.nosetest.local.conf
+++ b/test_project/cosmic-ray.nosetest.local.conf
@@ -1,0 +1,10 @@
+# Run the adam tests with nose
+--verbose
+run
+--test-runner=nose
+--baseline=10
+adam_tests.nosetest.local
+adam
+--
+-v
+tests/

--- a/test_project/cosmic-ray.pytest.dist.conf
+++ b/test_project/cosmic-ray.pytest.dist.conf
@@ -1,6 +1,7 @@
 # Run the adam tests with pytest
 --verbose
 run
+--dist
 --test-runner=pytest
 --baseline=10
 adam_tests.pytest.dist

--- a/test_project/cosmic-ray.pytest.dist.conf
+++ b/test_project/cosmic-ray.pytest.dist.conf
@@ -3,7 +3,7 @@
 run
 --test-runner=pytest
 --baseline=10
-adam_tests.pytest
+adam_tests.pytest.dist
 adam
 --
 -x

--- a/test_project/cosmic-ray.pytest.local.conf
+++ b/test_project/cosmic-ray.pytest.local.conf
@@ -1,0 +1,10 @@
+# Run the adam tests with pytest
+--verbose
+run
+--test-runner=pytest
+--baseline=10
+adam_tests.pytest.local
+adam
+--
+-x
+tests

--- a/test_project/cosmic-ray.unittest.dist.conf
+++ b/test_project/cosmic-ray.unittest.dist.conf
@@ -1,0 +1,10 @@
+# Run the adam tests with unittest
+--verbose
+run
+--dist
+--test-runner=unittest
+--baseline=10
+adam_tests.unittest.dist
+adam
+--
+tests

--- a/test_project/cosmic-ray.unittest.local.conf
+++ b/test_project/cosmic-ray.unittest.local.conf
@@ -3,7 +3,7 @@
 run
 --test-runner=unittest
 --baseline=10
-adam_tests.unittest
+adam_tests.unittest.local
 adam
 --
 tests

--- a/test_project/run_tests.sh
+++ b/test_project/run_tests.sh
@@ -1,11 +1,19 @@
 # This runs the "adam" tests, returning 0 if all mutants are killed, or 1 if
 # there's a survivor.
 
-cosmic-ray load cosmic-ray.unittest.conf
+cosmic-ray load cosmic-ray.unittest.dist.conf
 if [ $? != 0 ]; then exit 1; fi
-RESULT=`cosmic-ray survival-rate adam_tests.unittest`
+RESULT=`cosmic-ray survival-rate adam_tests.unittest.dist`
 if [ $RESULT != 0.00 ]; then
-    cosmic-ray report adam_tests.unittest
+    cosmic-ray report adam_tests.unittest.dist
+    exit 1
+fi
+
+cosmic-ray load cosmic-ray.unittest.local.conf
+if [ $? != 0 ]; then exit 1; fi
+RESULT=`cosmic-ray survival-rate adam_tests.unittest.local`
+if [ $RESULT != 0.00 ]; then
+    cosmic-ray report adam_tests.unittest.local
     exit 1
 fi
 

--- a/test_project/run_tests.sh
+++ b/test_project/run_tests.sh
@@ -9,11 +9,19 @@ if [ $RESULT != 0.00 ]; then
     exit 1
 fi
 
-cosmic-ray load cosmic-ray.pytest.conf
+cosmic-ray load cosmic-ray.pytest.dist.conf
 if [ $? != 0 ]; then exit 1; fi
-RESULT=`cosmic-ray survival-rate adam_tests.pytest`
+RESULT=`cosmic-ray survival-rate adam_tests.pytest.dist`
 if [ $RESULT != 0.00 ]; then
-    cosmic-ray report adam_tests.pytest
+    cosmic-ray report adam_tests.pytest.dist
+    exit 1
+fi
+
+cosmic-ray load cosmic-ray.pytest.local.conf
+if [ $? != 0 ]; then exit 1; fi
+RESULT=`cosmic-ray survival-rate adam_tests.pytest.local`
+if [ $RESULT != 0.00 ]; then
+    cosmic-ray report adam_tests.pytest.local
     exit 1
 fi
 

--- a/test_project/run_tests.sh
+++ b/test_project/run_tests.sh
@@ -1,55 +1,20 @@
 # This runs the "adam" tests, returning 0 if all mutants are killed, or 1 if
 # there's a survivor.
 
-cosmic-ray load cosmic-ray.unittest.dist.conf
-if [ $? != 0 ]; then exit 1; fi
-RESULT=`cosmic-ray survival-rate adam_tests.unittest.dist`
-if [ $RESULT != 0.00 ]; then
-    cosmic-ray report adam_tests.unittest.dist
-    exit 1
-fi
+TEST_CONFIGS="unittest.dist unittest.local pytest.dist pytest.local nosetest.dist nosetest.dist"
+for CONFIG in $TEST_CONFIGS; do
+    echo $CONFIG
+    cosmic-ray load cosmic-ray.$CONFIG.conf
+    if [ $? != 0 ]; then exit 1; fi
+    RESULT=`cosmic-ray survival-rate adam_tests.$CONFIG`
+    if [ $RESULT != 0.00 ]; then
+        cosmic-ray report adam_tests.$CONFIG
+        exit 1
+    fi
+done
 
-cosmic-ray load cosmic-ray.unittest.local.conf
-if [ $? != 0 ]; then exit 1; fi
-RESULT=`cosmic-ray survival-rate adam_tests.unittest.local`
-if [ $RESULT != 0.00 ]; then
-    cosmic-ray report adam_tests.unittest.local
-    exit 1
-fi
-
-cosmic-ray load cosmic-ray.pytest.dist.conf
-if [ $? != 0 ]; then exit 1; fi
-RESULT=`cosmic-ray survival-rate adam_tests.pytest.dist`
-if [ $RESULT != 0.00 ]; then
-    cosmic-ray report adam_tests.pytest.dist
-    exit 1
-fi
-
-cosmic-ray load cosmic-ray.pytest.local.conf
-if [ $? != 0 ]; then exit 1; fi
-RESULT=`cosmic-ray survival-rate adam_tests.pytest.local`
-if [ $RESULT != 0.00 ]; then
-    cosmic-ray report adam_tests.pytest.local
-    exit 1
-fi
-
-cosmic-ray load cosmic-ray.nosetest.dist.conf
-if [ $? != 0 ]; then exit 1; fi
-RESULT=`cosmic-ray survival-rate adam_tests.nosetest`
-if [ $RESULT != 0.00 ]; then
-    cosmic-ray report adam_tests.nosetest.dist
-    exit 1
-fi
-
-cosmic-ray load cosmic-ray.nosetest.local.conf
-if [ $? != 0 ]; then exit 1; fi
-RESULT=`cosmic-ray survival-rate adam_tests.nosetest`
-if [ $RESULT != 0.00 ]; then
-    cosmic-ray report adam_tests.nosetest.local
-    exit 1
-fi
-
-# Run import tests
+# #
+Run import tests
 cosmic-ray load cosmic-ray.import.conf
 if [ $? != 0 ]; then exit 1; fi
 RESULT=`cosmic-ray survival-rate import_tests`

--- a/test_project/run_tests.sh
+++ b/test_project/run_tests.sh
@@ -17,11 +17,19 @@ if [ $RESULT != 0.00 ]; then
     exit 1
 fi
 
-cosmic-ray load cosmic-ray.nosetest.conf
+cosmic-ray load cosmic-ray.nosetest.dist.conf
 if [ $? != 0 ]; then exit 1; fi
 RESULT=`cosmic-ray survival-rate adam_tests.nosetest`
 if [ $RESULT != 0.00 ]; then
-    cosmic-ray report adam_tests.nosetest
+    cosmic-ray report adam_tests.nosetest.dist
+    exit 1
+fi
+
+cosmic-ray load cosmic-ray.nosetest.local.conf
+if [ $? != 0 ]; then exit 1; fi
+RESULT=`cosmic-ray survival-rate adam_tests.nosetest`
+if [ $RESULT != 0.00 ]; then
+    cosmic-ray report adam_tests.nosetest.local
     exit 1
 fi
 

--- a/test_project/run_tests.sh
+++ b/test_project/run_tests.sh
@@ -13,8 +13,7 @@ for CONFIG in $TEST_CONFIGS; do
     fi
 done
 
-# #
-Run import tests
+# Run import tests
 cosmic-ray load cosmic-ray.import.conf
 if [ $? != 0 ]; then exit 1; fi
 RESULT=`cosmic-ray survival-rate import_tests`


### PR DESCRIPTION
@atodorov @boxed This pull request adds support for running all of the mutation testing locally rather than via celery workers. By default, the `exec` command spawns a new local process for each mutation rather than queuing the work in celery; to use celery you pass the "--dist" flag to `exec`. 

This work is motivated by several users - and in particular @boxed - who noted that the work needed to simpy try CR out was too high, and that it should be possible to simply take CR for a spin should be minimized. Hopefully this gets us closer.

If either or both of you has time, could you look the changes over? I'm pretty sure the functionality is in pretty good shape, though you should verify that if possible. I'm more concerned that the documentation is correct and helpful, i.e. that new potential users will find it easy to try CR our quickly.

This line of work is not complete, but I think it's ready to get in front of the general public. In particular, I'm probably going to create an abstraction/plugin system for "execution modes" of which "local" and "celery" will be the first two examples. This will give us (or others) the flexibility to add other distribution modes if we want, perhaps supporting environments like server clusters or cloud systems.

Thanks!