### PR TITLE
Fixed importing ImportError for Python 3.6 and after

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     - python: 3.4
     - python: 3.5
     - python: 3.5-dev
+    - python: 3.6
     - python: nightly
   fast_finish: true
   allow_failures:

--- a/cosmic_ray/importing.py
+++ b/cosmic_ray/importing.py
@@ -23,6 +23,9 @@ class ASTLoader:  # pylint:disable=old-style-class,too-few-public-methods
         self._ast = ast
         self._name = name
 
+    def create_module(self, spec):
+        return None
+
     def exec_module(self, mod):
         exec(compile(self._ast, self._name, 'exec'),  # pylint:disable=exec-used
              mod.__dict__)


### PR DESCRIPTION
When using Python 3.6 with cosmic-ray 1.0.0a1, found
that there is a ImportError cause by Python 3.6.

[class importlib.abc.Loader.create_module](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.create_module)
is now a must to defined in 3.6.

```python
job ID 22:Outcome.KILLED:hello
command: cosmic-ray worker hello number_replacer 0 nose -- test_hello.py
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/usr/lib/python3.6/site-packages/nose/loader.py", line 417, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python3.6/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python3.6/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/usr/lib/python3.6/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.6/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 675, in _load
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
  File "//mutation-testing-in-patterns/python/example_04/test_hello.py", line 1, in <module>
    import hello
ImportError: loaders that define exec_module() must also define create_module()
```