### PR TITLE
add zero iteration operator only for for loop

### DIFF
--- a/cosmic_ray/operators/zero_iteration_loop.py
+++ b/cosmic_ray/operators/zero_iteration_loop.py
@@ -12,7 +12,7 @@ class ZeroIterationLoop(Operator):
 
     def mutate(self, node, _):
         """Modify the For loop to evaluate to None"""
-        empty_list_node = ast.List(elts=[], ctx=ast.Load)
+        empty_list_node = ast.List(elts=[], ctx=ast.Load())
         new_node = ast.For(node.target, empty_list_node, node.body,
                            node.orelse)
         return new_node

--- a/cosmic_ray/operators/zero_iteration_loop.py
+++ b/cosmic_ray/operators/zero_iteration_loop.py
@@ -1,0 +1,18 @@
+import ast
+
+from .operator import Operator
+
+
+class ZeroIterationLoop(Operator):
+
+    """An operator that modifies numeric constants."""
+
+    def visit_For(self, node):  # noqa
+        return self.visit_mutation_site(node)
+
+    def mutate(self, node, _):
+        """Modify the For loop to evaluate to None"""
+        empty_list_node = ast.List(elts=[], ctx=ast.Load)
+        new_node = ast.For(node.target, empty_list_node, node.body,
+                           node.orelse)
+        return new_node

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,9 @@ operators = [
 
     'break_continue_replacement ='
     'cosmic_ray.operators.break_continue:ReplaceBreakWithContinue',
+
+    'zero_iteration_loop ='
+    'cosmic_ray.operators.zero_iteration_loop:ZeroIterationLoop',
 ]
 
 INSTALL_REQUIRES = [

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -18,6 +18,7 @@ from cosmic_ray.operators.boolean_replacer import (ReplaceTrueFalse,
 from cosmic_ray.operators.break_continue import (ReplaceBreakWithContinue,
                                                  ReplaceContinueWithBreak)
 from cosmic_ray.operators.number_replacer import NumberReplacer
+from cosmic_ray.operators.zero_iteration_loop import ZeroIterationLoop
 from cosmic_ray.mutating import MutatingCore
 
 
@@ -62,6 +63,7 @@ OPERATOR_SAMPLES = [
     (MutateUnaryOperator, 'x = -1'),
     (MutateBinaryOperator, 'x * y'),
     (MutateBinaryOperator, 'x - y'),
+    (ZeroIterationLoop, 'for i in range(1,2): pass'),
 ]
 
 

--- a/test_project/adam.py
+++ b/test_project/adam.py
@@ -91,3 +91,13 @@ def trigger_infinite_loop():
     # when `while object()` becomes `while not object()`
     # the code below will be triggered
     return result
+
+
+def single_iteration():
+    result = None
+    iter = [object()]
+
+    for i in iter:
+        result = True
+
+    return result

--- a/test_project/tests/test_adam.py
+++ b/test_project/tests/test_adam.py
@@ -71,3 +71,6 @@ class Tests(unittest.TestCase):
 
     def test_trigger_infinite_loop(self):
         self.assertTrue(adam.trigger_infinite_loop())
+
+    def test_single_iteration(self):
+        self.assertTrue(adam.single_iteration())


### PR DESCRIPTION
I am still struggling with 3 issues here:
1. 2 tests are affected: use continue and use break, since they use for.
2. When I mutate manually I see, the tests fail, when I run it as part of the load, it says the mutant is alive. How should I proceed?
3. I do not know how to handle mutant which rely on the return value of the for loop, for example:
```
for i in range(5):
    ....
return i  
```
This creates incompetent mutants, since i is now UnreferencedLocalVariable.