### PR TITLE
Remove Python 3.5 from travis's "allowed failures".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - python: nightly
-    - python: 3.5 # until https://github.com/travis-ci/travis-ci/issues/7708 is resolved
 
 install:
   - python setup.py install


### PR DESCRIPTION
Whatever issue we were seeing seems to have been resolved.