### PR TITLE
Print number of mutations after init command

### DIFF
--- a/cosmic_ray/commands/init.py
+++ b/cosmic_ray/commands/init.py
@@ -37,3 +37,6 @@ def init(modules,
         for module, ops in counts.items()
         for opname, count in ops.items()
         for occurrence in range(count))
+
+    msg = "Created {} mutations to test."
+    print(msg.format(len(list(work_db.work_items))))


### PR DESCRIPTION
Informs the user how many mutations there are to test when `init` is run.

```
(.venv-cosmic-ray) C:\dev\cosmic-ray>cosmic-ray init --baseline=1 test_session cosmic_ray -- test
Created 714 mutations to test.
```

Part of #219.