### PR TITLE
Mention Python 3 more explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 *"Four human beings -- changed by space-born cosmic rays into something more than merely human."*
 *— The Fantastic Four*
 
-Cosmic Ray is a mutation testing tool for Python.
+Cosmic Ray is a mutation testing tool for Python 3.
 
 ## Cosmic Ray is still learning how to walk!
 


### PR DESCRIPTION
Prevent issues like #224

I know there's a badge, but I tried to run cosmic-ray on a Python 2 project without realising it's Python 3 only.