### PR TITLE
Properly using @abstractmethod.

### DIFF
--- a/cosmic_ray/execution/execution_engine.py
+++ b/cosmic_ray/execution/execution_engine.py
@@ -4,4 +4,4 @@ import abc
 class ExecutionEngine(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __call__(self, timeout, pending_work, config):
-        raise NotImplemented()
+        pass

--- a/cosmic_ray/testing/test_runner.py
+++ b/cosmic_ray/testing/test_runner.py
@@ -41,7 +41,7 @@ class TestRunner(metaclass=abc.ABCMeta):
         passed. `result` is any object that is appropriate to provide
         more information about the success/failure of the tests.
         """
-        raise NotImplemented()
+        pass
 
     def __call__(self):
         """Call `_run()` and return a `WorkRecord` with the results.


### PR DESCRIPTION
Instead of uselessly throwing exceptions from them, we're just calling pass now.