### PR TITLE
--version now reports the actual version, not a hard-coded string.

### DIFF
--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -25,6 +25,7 @@ from cosmic_ray.testing.test_runner import TestOutcome
 from cosmic_ray.timing import Timer
 from cosmic_ray.util import redirect_stdout
 from cosmic_ray.work_db import use_db, WorkDB
+from cosmic_ray.version import __version__
 
 LOG = logging.getLogger()
 
@@ -303,9 +304,10 @@ def main(argv=None):
                   lambda *args: sys.exit(_SIGNAL_EXIT_CODE_BASE + signal.SIGINT))
 
     try:
+        print(__version__)
         return dsc.main(
             'cosmic-ray',
-            'cosmic-ray v.2',
+            'Cosmic Ray {}'.format(__version__),
             argv=argv,
             doc_template=DOC_TEMPLATE,
             common_option_handler=common_option_handler,

--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -304,7 +304,6 @@ def main(argv=None):
                   lambda *args: sys.exit(_SIGNAL_EXIT_CODE_BASE + signal.SIGINT))
 
     try:
-        print(__version__)
         return dsc.main(
             'cosmic-ray',
             'Cosmic Ray {}'.format(__version__),


### PR DESCRIPTION
Also the version string follows the recommendation is the GNU style guide
that the given name should be the canonical program name, not the filename.