### PR TITLE
Consistent work item naming

### DIFF
--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -46,18 +46,18 @@ def handle_baseline(args):
     test_runner = cosmic_ray.plugins.get_test_runner(
         config['test-runner']['name'],
         config['test-runner']['args'])
-    work_record = test_runner()
+    work_item = test_runner()
     # note: test_runner() results are meant to represent
     # status codes when executed against mutants.
     # SURVIVED means that the test suite executed without any error
     # hence CR thinks the mutant survived. However when running the
     # baseline execution we don't have mutations and really want the
     # test suite to report PASS, hence the comparison below!
-    if work_record.test_outcome != TestOutcome.SURVIVED:
+    if work_item.test_outcome != TestOutcome.SURVIVED:
         # baseline failed, print whatever was returned
         # from the test runner and exit
         LOG.error('baseline failed')
-        print(''.join(work_record.data))
+        print(''.join(work_item.data))
         return 2
 
     return os.EX_OK
@@ -191,7 +191,7 @@ def handle_dump(args):
     session_file = get_db_name(args['<session-file>'])
 
     with use_db(session_file, WorkDB.Mode.open) as database:
-        for record in database.work_records:
+        for record in database.work_items:
             print(json.dumps(record))
 
     return os.EX_OK
@@ -280,13 +280,13 @@ def handle_worker(args):
 
     with open(os.devnull, 'w') as devnull:
         with redirect_stdout(sys.stdout if args['--keep-stdout'] else devnull):
-            work_record = cosmic_ray.worker.worker(
+            work_item = cosmic_ray.worker.worker(
                 args['<module>'],
                 operator,
                 int(args['<occurrence>']),
                 test_runner)
 
-    sys.stdout.write(json.dumps(work_record))
+    sys.stdout.write(json.dumps(work_item))
 
     return os.EX_OK
 

--- a/cosmic_ray/commands/execute.py
+++ b/cosmic_ray/commands/execute.py
@@ -16,12 +16,12 @@ results.
             config, timeout = work_db.get_config()
             engine_config = config['execution-engine']
             executor = get_execution_engine(engine_config['name'])
-            work_records = executor(timeout,
-                                    work_db.pending_work,
-                                    config)
+            work_items = executor(timeout,
+                                  work_db.pending_work_items,
+                                  config)
 
-            for work_record in work_records:
-                work_db.update_work_record(work_record)
+            for work_item in work_items:
+                work_db.update_work_item(work_item)
     except FileNotFoundError as exc:
         raise FileNotFoundError(str(exc).replace(
             'Requested file', 'Corresponding database', 1)) from exc

--- a/cosmic_ray/commands/init.py
+++ b/cosmic_ray/commands/init.py
@@ -3,7 +3,7 @@ import logging
 import uuid
 
 import cosmic_ray.modules
-from cosmic_ray.work_record import WorkRecord
+from cosmic_ray.work_item import WorkItem
 
 LOG = logging.getLogger()
 
@@ -30,10 +30,10 @@ def init(modules,
         config=config,
         timeout=timeout)
 
-    work_db.clear_work_records()
+    work_db.clear_work_items()
 
-    work_db.add_work_records(
-        WorkRecord(
+    work_db.add_work_items(
+        WorkItem(
             job_id=uuid.uuid4().hex,
             module=module.__name__,
             operator=opname,

--- a/cosmic_ray/execution/execution_engine.py
+++ b/cosmic_ray/execution/execution_engine.py
@@ -4,10 +4,12 @@ import abc
 
 
 class ExecutionEngine(metaclass=abc.ABCMeta):
-    "Base class for exection engine plugins."
+    "Base class for execution engine plugins."
     @abc.abstractmethod
     def __call__(self, timeout, pending_work, config):
-        """Execute jobs in `pending_work`, spending no more than `timeout` seconds for
+        """Execute jobs in `pending_work_items`.
+
+        Spend no more than `timeout` seconds for
         a single job, using `config` to control the work.
         """
         pass

--- a/cosmic_ray/execution/local.py
+++ b/cosmic_ray/execution/local.py
@@ -6,6 +6,6 @@ from ..worker import worker_process
 
 class LocalExecutionEngine(ExecutionEngine):
     "Execution engine that runs jobs on the local machine."
-    def __call__(self, timeout, pending_work, config):
-        for work_record in pending_work:
-            yield worker_process(work_record, timeout, config)
+    def __call__(self, timeout, pending_work_items, config):
+        for work_item in pending_work_items:
+            yield worker_process(work_item, timeout, config)

--- a/cosmic_ray/reporting.py
+++ b/cosmic_ray/reporting.py
@@ -5,29 +5,29 @@ from cosmic_ray.testing.test_runner import TestOutcome
 from cosmic_ray.worker import WorkerOutcome
 
 
-def _print_item(work_record, full_report):
-    data = work_record.data
-    outcome = work_record.worker_outcome
+def _print_item(work_item, full_report):
+    data = work_item.data
+    outcome = work_item.worker_outcome
     if outcome in [WorkerOutcome.NORMAL, WorkerOutcome.EXCEPTION]:
-        outcome = work_record.test_outcome
+        outcome = work_item.test_outcome
     ret_val = [
         'job ID {}:{}:{}'.format(
-            work_record.job_id,
+            work_item.job_id,
             outcome,
-            work_record.module),
-        'command: {}'.format(work_record.command_line or '')
+            work_item.module),
+        'command: {}'.format(work_item.command_line or '')
     ]
     if outcome == TestOutcome.KILLED and not full_report:
         ret_val = []
-    elif work_record.worker_outcome == WorkerOutcome.TIMEOUT:
+    elif work_item.worker_outcome == WorkerOutcome.TIMEOUT:
         if full_report:
             ret_val.append("timeout: {:.3f} sec".format(data))
         else:
             ret_val = []
-    elif work_record.worker_outcome in [WorkerOutcome.NORMAL,
-                                        WorkerOutcome.EXCEPTION]:
+    elif work_item.worker_outcome in [WorkerOutcome.NORMAL,
+                                      WorkerOutcome.EXCEPTION]:
         ret_val += data
-        ret_val += work_record.diff
+        ret_val += work_item.diff
 
     # for presentation purposes only
     if ret_val:
@@ -37,7 +37,7 @@ def _print_item(work_record, full_report):
 
 
 def is_killed(record):
-    """Determines if a WorkRecord should be considered "killed".
+    """Determines if a WorkItem should be considered "killed".
     """
     if record.worker_outcome == WorkerOutcome.TIMEOUT:
         return True
@@ -51,7 +51,7 @@ def create_report(records, show_pending, full_report=False):
     """Generate the lines of a simple report.
 
     Args:
-      records: An iterable of `WorkRecord`s.
+      records: An iterable of `WorkItem`s.
       show_pending: Show output for records which are pending.
       full_report: Whether to report on mutants that were killed.
     """
@@ -81,7 +81,7 @@ def create_report(records, show_pending, full_report=False):
 
 
 def survival_rate(records):
-    """Calcuate the survival rate for a sequence of WorkRecords.
+    """Calcuate the survival rate for a series of WorkItems.
     """
     total_jobs = 0
     pending_jobs = 0

--- a/cosmic_ray/testing/test_runner.py
+++ b/cosmic_ray/testing/test_runner.py
@@ -4,7 +4,7 @@ import abc
 import sys
 import traceback
 
-from cosmic_ray.work_record import WorkRecord
+from cosmic_ray.work_item import WorkItem
 
 
 class TestOutcome:
@@ -47,21 +47,21 @@ class TestRunner(metaclass=abc.ABCMeta):
         pass
 
     def __call__(self):
-        """Call `_run()` and return a `WorkRecord` with the results.
+        """Call `_run()` and return a `WorkItem` with the results.
 
-        Returns: A `WorkRecord` with the `test_outcome` and `data` fields
+        Returns: A `WorkItem` with the `test_outcome` and `data` fields
             filled in.
         """
         try:
             test_result = self._run()
             if test_result[0]:
-                return WorkRecord(
+                return WorkItem(
                     test_outcome=TestOutcome.SURVIVED,
                     data=test_result[1])
-            return WorkRecord(
+            return WorkItem(
                 test_outcome=TestOutcome.KILLED,
                 data=test_result[1])
         except Exception:  # pylint: disable=broad-except
-            return WorkRecord(
+            return WorkItem(
                 test_outcome=TestOutcome.INCOMPETENT,
                 data=traceback.format_exception(*sys.exc_info()))

--- a/cosmic_ray/work_db.py
+++ b/cosmic_ray/work_db.py
@@ -8,7 +8,7 @@ from enum import Enum
 # for something quicker if not. But for now it's *very* convenient.
 import tinydb
 
-from .work_record import WorkRecord
+from .work_item import WorkItem
 
 
 class WorkDB:
@@ -91,17 +91,15 @@ class WorkDB:
         return (record['config'],
                 record['timeout'])
 
-    def add_work_records(self, records):
-        """Add a sequence of WorkRecords.
+    def add_work_items(self, work_items):
+        """Add a sequence of WorkItems.
 
         Args:
-          records: An iterable of tuples of the form `(module-name,
-            operator-name, occurrence)`.
-
+          work_items: An iterable of WorkItems.
         """
-        self._work_items.insert_multiple(records)
+        self._work_items.insert_multiple(work_items)
 
-    def clear_work_records(self):
+    def clear_work_items(self):
         """Clear all work items from the session.
 
         This removes any associated results as well.
@@ -109,34 +107,33 @@ class WorkDB:
         self._work_items.purge()
 
     @property
-    def work_records(self):
-        """The sequence of `WorkItem`s in the session.
+    def work_items(self):
+        """The sequence of WorkItems in the session.
 
         This include both complete and incomplete items.
 
         Each work item is a dict with the keys `module-name`, `op-name`, and
         `occurrence`. Items with results will also have the keys `results-type`
         and `results-data`.
-
         """
-        return (WorkRecord(r) for r in self._work_items.all())
+        return (WorkItem(r) for r in self._work_items.all())
 
-    def update_work_record(self, work_record):
-        """Updates an existing WorkRecord by job_id.
+    def update_work_item(self, work_item):
+        """Updates an existing WorkItem by job_id.
 
         Args:
-            work_record: A WorkRecord representing the new state of a job.
+            work_item: A WorkItem representing the new state of a job.
 
         Raises:
           KeyError: If there is no existing record with the same job_id.
         """
         self._work_items.update(
-            work_record,
-            tinydb.Query().job_id == work_record.job_id)
+            work_item,
+            tinydb.Query().job_id == work_item.job_id)
 
     @property
-    def pending_work(self):
-        """The sequence of pending `WorkItem`s in the session."""
+    def pending_work_items(self):
+        """The sequence of pending WorkItems in the session."""
         table = self._work_items
         work_item = tinydb.Query()
 
@@ -147,7 +144,7 @@ class WorkDB:
             work_item.worker_outcome.test(
                 lambda val: val is None))
 
-        return (WorkRecord(r) for r in pending)
+        return (WorkItem(r) for r in pending)
 
 
 @contextlib.contextmanager

--- a/cosmic_ray/work_item.py
+++ b/cosmic_ray/work_item.py
@@ -1,7 +1,7 @@
-"""A `WorkRecord` carries information about potential and completed work in the
+"""A `WorkItem` carries information about potential and completed work in the
 Cosmic Ray system.
 
-`WorkRecord` is one of the central structures in CR. It can describe both work
+`WorkItem` is one of the central structures in CR. It can describe both work
 to be done and work that has been done, and it indicates how test sessions have
 completed.
 """
@@ -87,8 +87,8 @@ def make_record(name, fields=(), docstring=""):
     return rec
 
 
-WorkRecord = make_record(  # pylint: disable=invalid-name
-    'WorkRecord',
+WorkItem = make_record(  # pylint: disable=invalid-name
+    'WorkItem',
 
     [
         # Arbitrary data returned by the concrete TestRunner to provide more

--- a/plugins/execution-engines/celery3/cosmic_ray_celery3_engine/engine.py
+++ b/plugins/execution-engines/celery3/cosmic_ray_celery3_engine/engine.py
@@ -1,10 +1,10 @@
 "Implementation of the celery3 execution engine plugin."
 
 from cosmic_ray.execution.execution_engine import ExecutionEngine
-from cosmic_ray.work_record import WorkRecord
+from cosmic_ray.work_item import WorkItem
 
 from .app import APP
-from .worker import execute_work_records
+from .worker import execute_work_items
 
 
 class CeleryExecutionEngine(ExecutionEngine):
@@ -13,13 +13,13 @@ class CeleryExecutionEngine(ExecutionEngine):
         purge_queue = config['execution-engine'].get('purge-queue', True)
 
         try:
-            results = execute_work_records(
+            results = execute_work_items(
                 timeout,
                 pending_work,
                 config)
 
             for result in results:
-                yield WorkRecord(result.get())
+                yield WorkItem(result.get())
         finally:
             if purge_queue:
                 APP.control.purge()

--- a/plugins/execution-engines/celery3/cosmic_ray_celery3_engine/worker.py
+++ b/plugins/execution-engines/celery3/cosmic_ray_celery3_engine/worker.py
@@ -10,7 +10,7 @@ LOG = get_logger(__name__)
 
 
 @APP.task(name='cosmic_ray_celery3_engine.worker')
-def worker_task(work_record,
+def worker_task(work_item,
                 timeout,
                 config):
     """The celery task which performs a single mutation and runs a test suite.
@@ -18,26 +18,26 @@ def worker_task(work_record,
     This runs `cosmic-ray worker` in a subprocess and returns the results,
     passing `config` to it via stdin.
 
-    Returns: An updated WorkRecord
+    Returns: An updated WorkItem
 
     """
-    return worker_process(work_record, timeout, config)
+    return worker_process(work_item, timeout, config)
 
 
-def execute_work_records(timeout,
-                         work_records,
-                         config):
+def execute_work_items(timeout,
+                       work_items,
+                       config):
     """Execute a suite of tests for a given set of work items.
 
     Args:
       timeout: The max length of time to let a test run before it's killed.
-      work_records: An iterable of `work_db.WorkItem`s.
+      work_items: An iterable of `work_db.WorkItem`s.
       config: The configuration to use for the test execution.
 
-    Returns: An iterable of WorkRecords.
+    Returns: An iterable of WorkItems.
     """
     return celery.group(
-        worker_task.delay(work_record,
+        worker_task.delay(work_item,
                           timeout,
                           config)
-        for work_record in work_records)
+        for work_item in work_items)

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -38,7 +38,7 @@ def test_e2e(project_root, test_runner, engine):
 
     session_path = project_root / session
     with use_db(str(session_path), WorkDB.Mode.open) as work_db:
-        rate = survival_rate(work_db.work_records)
+        rate = survival_rate(work_db.work_items)
         assert rate == 0.0
 
 
@@ -51,7 +51,7 @@ def test_importing(project_root):
 
     session_path = project_root / session
     with use_db(str(session_path), WorkDB.Mode.open) as work_db:
-        rate = survival_rate(work_db.work_records)
+        rate = survival_rate(work_db.work_items)
         assert rate == 0.0
 
 
@@ -64,7 +64,7 @@ def test_empty___init__(project_root):
 
     session_path = project_root / session
     with use_db(str(session_path), WorkDB.Mode.open) as work_db:
-        rate = survival_rate(work_db.work_records)
+        rate = survival_rate(work_db.work_items)
         assert rate == 0.0
 
 

--- a/test/unittests/test_command_line_processing.py
+++ b/test/unittests/test_command_line_processing.py
@@ -13,7 +13,7 @@ import cosmic_ray.plugins
 import cosmic_ray.util
 import cosmic_ray.worker
 from cosmic_ray.testing.test_runner import TestOutcome
-from cosmic_ray.work_record import WorkRecord
+from cosmic_ray.work_item import WorkItem
 
 
 @pytest.fixture
@@ -96,8 +96,8 @@ def test_baseline_failure_returns_2(monkeypatch, local_unittest_config, session_
     def killed_mutant(*args):
         "Simulates a test run where a the tests fails."
         def inner():
-            return WorkRecord(test_outcome=TestOutcome.KILLED,
-                              data=[])
+            return WorkItem(test_outcome=TestOutcome.KILLED,
+                            data=[])
         return inner
 
     monkeypatch.setattr(cosmic_ray.plugins, 'get_test_runner', killed_mutant)
@@ -110,8 +110,8 @@ def test_baseline_success_returns_EX_OK(monkeypatch, local_unittest_config, sess
     def surviving_mutant(*args):
         "Simulates a test run where a the tests succeed."
         def inner():
-            return WorkRecord(test_outcome=TestOutcome.SURVIVED,
-                              data=[])
+            return WorkItem(test_outcome=TestOutcome.SURVIVED,
+                            data=[])
         return inner
 
     monkeypatch.setattr(cosmic_ray.plugins, 'get_test_runner', surviving_mutant)

--- a/test/unittests/test_record.py
+++ b/test/unittests/test_record.py
@@ -1,4 +1,4 @@
-from cosmic_ray.work_record import make_record
+from cosmic_ray.work_item import make_record
 from hypothesis import given, assume
 import hypothesis.strategies as ST
 import pytest

--- a/test/unittests/test_worker.py
+++ b/test/unittests/test_worker.py
@@ -1,6 +1,6 @@
 from cosmic_ray.operators import zero_iteration_loop
 from cosmic_ray.plugins import get_test_runner
-from cosmic_ray.work_record import WorkRecord
+from cosmic_ray.work_item import WorkItem
 from cosmic_ray.worker import worker, WorkerOutcome
 
 from path_utils import DATA_DIR, excursion, extend_path
@@ -11,7 +11,7 @@ def test_no_test_return_value():
         test_runner = get_test_runner("unittest", ".")
         result = worker("a.b", zero_iteration_loop.ZeroIterationLoop,
                         100, test_runner)
-        expected = WorkRecord(
+        expected = WorkItem(
             data=None,
             test_outcome=None,
             worker_outcome=WorkerOutcome.NO_TEST,


### PR DESCRIPTION
Previously there was a mix of WorkItem, WorkRecord and just 'work'.

I chose WorkItem primarily because it fits better in contexts such
as "pending work items" which sounds like work awaiting completion
compared to "pending work records" which sounds like records waiting
to be inserted.