### PR TITLE
pytest: handle non-zero exit code

### DIFF
--- a/cosmic_ray/testing/test_runner.py
+++ b/cosmic_ray/testing/test_runner.py
@@ -15,6 +15,16 @@ class TestOutcome:
     INCOMPETENT = 'incompetent'
 
 
+class TestRunnerFailure(Exception):
+    """Failure reported from a test runner.
+    """
+    def __init__(self, msg, exit_code=None, output=None):
+        self.msg = msg
+        self.exit_code = exit_code
+        self.output = output
+        Exception.__init__(self, msg)
+
+
 class TestRunner(metaclass=abc.ABCMeta):
     """Specifies the interface for test runners in the system.
 

--- a/plugins/test-runners/pytest/cosmic_ray_pytest_runner/runner.py
+++ b/plugins/test-runners/pytest/cosmic_ray_pytest_runner/runner.py
@@ -1,8 +1,10 @@
 "Implementation of a test-runner for pytest-based tests."
 
+from io import StringIO
+
 import pytest
 
-from cosmic_ray.testing.test_runner import TestRunner
+from cosmic_ray.testing.test_runner import TestRunner, TestRunnerFailure
 from cosmic_ray.util import redirect_stdout
 
 
@@ -27,14 +29,7 @@ class PytestRunner(TestRunner):
     """
 
     def _run(self):
-        from io import StringIO
         collector = ResultCollector()
-
-        class TestRunnerFailure(Exception):
-            def __init__(self, msg, exit_code, output):
-                self.msg = msg
-                self.exit_code = exit_code
-                self.output = output
 
         args = self.test_args
         if args:


### PR DESCRIPTION
TODO:
 - [x] TestRunnerFailure should be made available for test runners in general?!  Should it get derived from some `CosmicRayException` base?  Should there be a `exceptions` module for this?
 - [x] in a test only `io.StringIO` is used (without the compat).  Should be done here then also I assume?