### PR TITLE
UnittestRunner: remove useless-super-delegation

### DIFF
--- a/cosmic_ray/testing/unittest_runner.py
+++ b/cosmic_ray/testing/unittest_runner.py
@@ -16,9 +16,6 @@ class UnittestRunner(TestRunner):
 
     """
 
-    def __init__(self, test_args):  # pylint: disable=useless-super-delegation
-        super().__init__(test_args)
-
     def _run(self):
         suite = unittest.TestLoader().discover(self.test_args)
         result = unittest.TestResult()


### PR DESCRIPTION
It was added in 96b20fb apparently in an attempt to please pylint it
seems.