### PR TITLE
Travis: remove install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,7 @@ matrix:
   - python: nightly
 
 install:
-- python setup.py install
-- pip install -e ".[test]"
-- pushd plugins/execution-engines/celery3
-- python setup.py install
-- cd ../../test-runners/pytest
-- python setup.py install
-- cd ../nose
-- python setup.py install
-- popd
-- cosmic-ray test-runners
+- pip install tox
 
 services: rabbitmq
 


### PR DESCRIPTION
tox takes care of installation.

This removes the call to `cosmic-ray test-runners`, which should be
covered by a real integration test instead (if not done already).