### PR TITLE
Add logging to load_config

### DIFF
--- a/cosmic_ray/config.py
+++ b/cosmic_ray/config.py
@@ -1,20 +1,25 @@
 """Configuration module."""
+import logging
 import sys
 
 import yaml
+
+LOG = logging.getLogger()
 
 
 def load_config(filename=None):
     """Load a configuration from a file or stdin.
 
-    If `filename` is `None`, then this reads its configuration from stdin.
+    If `filename` is `None`, then configuration gets read from stdin.
 
     Returns: A configuration dict.
     """
-    if filename is None:
+    if filename is None or filename == '-':
+        LOG.info('Reading config from stdin')
         return yaml.safe_load(sys.stdin)
 
     with open(filename, mode='rt') as handle:
+        LOG.info('Reading config from %r', filename)
         return yaml.safe_load(handle)
 
 


### PR DESCRIPTION
I've tried to run a command from the report ("cosmic-ray worker
module zero_iteration_loop 9") and it was waiting for input on stdin.

This additional logging should help in this case (when run in verbose
mode).