### PR TITLE
Add coverage reporting via codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+branch = True
+include = cosmic_ray/*,test/*
+
+[report]
+exclude_lines =
+    raise NotImplementedError
+    pragma: no cover
+# Branch coverage: ignore default and assert statements.
+partial_branches =
+    \s+#\s*(pragma|PRAGMA)[:\s]?\s*(no|NO)\s*(branch|BRANCH)
+    ^\s*assert\s

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
   allow_failures:
   - python: nightly
 
+env:
+  global:
+  - TOXENV=py-coverage
+
 install:
 - python setup.py install
 - pip install -e ".[test]"
@@ -31,8 +35,15 @@ before_script:
 - popd
 
 script:
-- tox -e py
+- tox
 - if [[ "$TRAVIS_PYTHON_VERSION" == '3.6' ]]; then tox -e lint,style,docs; fi
+
+after_success:
+- |
+  pip install codecov
+  coverage xml
+  codecov_flags=py${TRAVIS_PYTHON_VERSION//./}
+  codecov --required -X search gcov pycov -f coverage.xml --flags $codecov_flags
 
 # When we push to 'release', the python-3.6 travis run should do a deployment.
 deploy:

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,12 @@ description = run the unit tests with pytest under {basepython}
 deps = plugins/test-runners/pytest
        plugins/test-runners/nose
        plugins/execution-engines/celery3
-commands = pytest {posargs:test}
+       coverage: pytest-cov
+commands = pytest {env:_EXTRA_COMMAND_ARGS:} {posargs:test}
 extras = test
+usedevelop = True
+setenv =
+    coverage: _EXTRA_COMMAND_ARGS=--cov=cosmic_ray --cov=test --cov-report=term-missing:skip-covered
 
 [testenv:lint]
 deps = pylint == 1.7.4


### PR DESCRIPTION
Fixes https://github.com/sixty-north/cosmic-ray/issues/317.

Running `tox -e py-coverage` locally gives me:
```
----------- coverage: platform linux, python 3.6.3-final-0 -----------
Name                                                  Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------------------------------------
cosmic_ray/cli.py                                       135      7     34      9    89%   105, 110, 131, 196, 316, 331, 357, 104->105, 109->110, 111->131, 195->196, 274->277, 315->316, 327->exit, 330->331, 356->357
cosmic_ray/commands/execute.py                           28      3      4      0    84%   21-23
cosmic_ray/commands/format.py                            64     64     24      0     0%   3-110
cosmic_ray/commands/new_config.py                        16     12      4      0    20%   28-44
cosmic_ray/counting.py                                   17      1      5      0    95%   27
cosmic_ray/execution/execution_engine.py                  4      1      0      0    75%   15
cosmic_ray/modules.py                                    28      1     15      1    95%   63, 61->63
cosmic_ray/mutating.py                                   25      1      2      0    96%   75
cosmic_ray/operators/binary_operator_replacement.py      17      0      4      1    95%   15->19
cosmic_ray/operators/boolean_replacer.py                 65     20     20      5    66%   24, 31, 54-64, 83-93, 23->24, 29->31, 53->54, 82->83, 131->exit
cosmic_ray/operators/operator.py                         16      5      2      0    61%   25, 47-53
cosmic_ray/parsing.py                                    19      3      2      0    86%   25-27
cosmic_ray/plugins.py                                    15      1      0      0    93%   53
cosmic_ray/print_visitor.py                              16     16      0      0     0%   6-36
cosmic_ray/progress.py                                   24      4      4      0    71%   65-68
cosmic_ray/reporting.py                                  60     34     36      1    41%   9-36, 58-80, 45->47
cosmic_ray/testing/test_runner.py                        23      3      2      0    88%   47, 64-65
cosmic_ray/util.py                                       28     18      4      0    44%   6-37, 42-51
cosmic_ray/work_db.py                                    60      4      8      0    94%   109-110, 190-191
cosmic_ray/worker.py                                     63      5      8      1    92%   106-107, 149-151, 145->149
-------------------------------------------------------------------------------------------------
TOTAL                                                  1278    203    252     18    81%

33 files skipped due to complete coverage.
```