### PR TITLE
Detect ast.Compare nodes where the right-hand-side value is None

### DIFF
--- a/cosmic_ray/operators/comparison_operator_replacement.py
+++ b/cosmic_ray/operators/comparison_operator_replacement.py
@@ -10,6 +10,7 @@ from ..util import build_mutations, compare_ast
 OPERATORS = (ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE,
              ast.Is, ast.IsNot, ast.In, ast.NotIn)
 
+
 def _all_ops(from_op):
     """The sequence of operators which `from_op` could be mutated to.
 
@@ -36,6 +37,7 @@ def _all_ops(from_op):
         else:
             yield to_op
 
+
 _RHS_IS_NONE_OPS = {
     ast.Eq: [ast.IsNot],
     ast.NotEq: [ast.Is],
@@ -43,16 +45,19 @@ _RHS_IS_NONE_OPS = {
     ast.IsNot: [ast.Is],
 }
 
+
 def _rhs_is_none_ops(from_op):
     for key, value in _RHS_IS_NONE_OPS.items():
         if isinstance(from_op, key):
             yield from value
             return
 
+
 def _comparison_rhs_is_none(node):
     return ((len(node.comparators) == 1)
             and
             (compare_ast(node.comparators[0], ast.NameConstant(None))))
+
 
 def _build_mutations(node):
     """Given a Compare node, produce the list of mutated operations.

--- a/cosmic_ray/operators/comparison_operator_replacement.py
+++ b/cosmic_ray/operators/comparison_operator_replacement.py
@@ -5,13 +5,12 @@ comparison operator with another.
 import ast
 
 from .operator import Operator
-from ..util import build_mutations
+from ..util import build_mutations, compare_ast
 
 OPERATORS = (ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE,
              ast.Is, ast.IsNot, ast.In, ast.NotIn)
 
-
-def _to_ops(from_op):
+def _all_ops(from_op):
     """The sequence of operators which `from_op` could be mutated to.
 
     There are a number of potential replacements which we avoid because they
@@ -37,19 +36,57 @@ def _to_ops(from_op):
         else:
             yield to_op
 
+_RHS_IS_NONE_OPS = {
+    ast.Eq: [ast.IsNot],
+    ast.NotEq: [ast.Is],
+    ast.Is: [ast.IsNot],
+    ast.IsNot: [ast.Is],
+}
+
+def _rhs_is_none_ops(from_op):
+    for key, value in _RHS_IS_NONE_OPS.items():
+        if isinstance(from_op, key):
+            yield from value
+            return
+
+def _comparison_rhs_is_none(node):
+    return ((len(node.comparators) == 1)
+            and
+            (compare_ast(node.comparators[0], ast.NameConstant(None))))
+
+def _build_mutations(node):
+    """Given a Compare node, produce the list of mutated operations.
+
+    Depending on the details of the Compare node, different tactics
+    may be used to generate the list of mutations, in order to avoid
+    generating mutants which we know will be incompetent.
+
+    Args:
+        node: A Compare node.
+
+    Returns:
+        A sequence of (idx, to-op) tuples describing the mutations for `ops`.
+    """
+    assert isinstance(node, ast.Compare)
+    if _comparison_rhs_is_none(node):
+        ops = _rhs_is_none_ops
+    else:
+        ops = _all_ops
+    return build_mutations(node.ops, ops)
+
 
 class MutateComparisonOperator(Operator):
     """An operator that modifies comparisons."""
 
-    def visit_Compare(self, node):  # pylint: disable=invalid-name
+    def visit_Compare(self, node):
         """
             http://greentreesnakes.readthedocs.io/en/latest/nodes.html#Compare
         """
         return self.visit_mutation_site(
             node,
-            len(build_mutations(node.ops, _to_ops)))
+            len(_build_mutations(node)))
 
     def mutate(self, node, idx):
-        from_idx, to_op = build_mutations(node.ops, _to_ops)[idx]
+        from_idx, to_op = _build_mutations(node)[idx]
         node.ops[from_idx] = to_op()
         return node

--- a/cosmic_ray/util.py
+++ b/cosmic_ray/util.py
@@ -116,5 +116,4 @@ def compare_ast(node1, node2):
         return True
     elif isinstance(node1, list):
         return all(itertools.starmap(compare_ast, zip(node1, node2)))
-    else:
-        return node1 == node2
+    return node1 == node2

--- a/cosmic_ray/util.py
+++ b/cosmic_ray/util.py
@@ -1,5 +1,7 @@
 """Various utility functions with no better place to live.
 """
+import ast
+import itertools
 
 try:
     from contextlib import redirect_stdout
@@ -89,3 +91,30 @@ def build_mutations(ops, to_ops):
             for idx, from_op in enumerate(ops)
             for to_op in to_ops(from_op)
             if to_op is None or not isinstance(from_op, to_op)]
+
+
+def compare_ast(node1, node2):
+    """Compares two AST nodes for equality.
+
+    Ignores the lineno, col_offset and ctx attributes.
+
+    Args:
+        node1: An AST node.
+        node2: Another AST node.
+
+    Returns:
+        True if the nodes are equivalent, otherwise False.
+    """
+    if type(node1) is not type(node2):
+        return False
+    if isinstance(node1, ast.AST):
+        for k, v in vars(node1).items():
+            if k in ('lineno', 'col_offset', 'ctx'):
+                continue
+            if not compare_ast(v, getattr(node2, k)):
+                return False
+        return True
+    elif isinstance(node1, list):
+        return all(itertools.starmap(compare_ast, zip(node1, node2)))
+    else:
+        return node1 == node2

--- a/test/unittests/test_operators.py
+++ b/test/unittests/test_operators.py
@@ -62,6 +62,7 @@ OPERATOR_SAMPLES = [
     (ReplaceContinueWithBreak, 'while False: continue'),
     (NumberReplacer, 'x = 1'),
     (MutateComparisonOperator, 'if x > y: pass'),
+    (MutateComparisonOperator, 'if x is None: pass'),
     (MutateUnaryOperator, 'return not X'),
     (MutateUnaryOperator, 'x = -1'),
     (MutateBinaryOperator, 'x * y'),


### PR DESCRIPTION
This change avoids creating a whole class of incompetent mutants by detecting when the right-hand side value of a comparison operator is None, and restricting the set of replacement mutant operators to only those which can operate on None.