### PR TITLE
Reworked test runner failure

### DIFF
--- a/cosmic_ray/testing/test_runner.py
+++ b/cosmic_ray/testing/test_runner.py
@@ -18,19 +18,22 @@ class TestOutcome:
 class TestRunnerFailure(Exception):
     """Failure reported from a test runner.
     """
-    def __init__(self, msg, exit_code=None, output=None):
+    def __init__(self, msg, exit_code=None, output=None):  # pylint: disable=useless-super-delegation
         super().__init__(msg, exit_code, output)
 
     @property
     def msg(self):
+        "A message describing the failure."
         return self.args[0]
 
     @property
     def exit_code(self):
+        "The exit code of the test runner (if applicable)."
         return self.args[1]
 
     @property
     def output(self):
+        "The output of the test runner (if applicable)."
         return self.args[2]
 
 

--- a/cosmic_ray/testing/test_runner.py
+++ b/cosmic_ray/testing/test_runner.py
@@ -19,10 +19,19 @@ class TestRunnerFailure(Exception):
     """Failure reported from a test runner.
     """
     def __init__(self, msg, exit_code=None, output=None):
-        self.msg = msg
-        self.exit_code = exit_code
-        self.output = output
-        Exception.__init__(self, msg)
+        super().__init__(msg, exit_code, output)
+
+    @property
+    def msg(self):
+        return self.args[0]
+
+    @property
+    def exit_code(self):
+        return self.args[1]
+
+    @property
+    def output(self):
+        return self.args[2]
 
 
 class TestRunner(metaclass=abc.ABCMeta):


### PR DESCRIPTION
This makes TestRunnerFailure behave a little better with respect to producing strings. Now it uses Exception's __str__ and __repr__ to produce more meaningful strings.