### PR TITLE
Make `build_mutations` amenable to dynamic class generation

### DIFF
--- a/cosmic_ray/operators/binary_operator_replacement.py
+++ b/cosmic_ray/operators/binary_operator_replacement.py
@@ -31,9 +31,9 @@ class MutateBinaryOperator(Operator):
         """
         return self.visit_mutation_site(
             node,
-            len(build_mutations([node.op], _to_ops)))
+            len(build_mutations([type(node.op)], _to_ops)))
 
     def mutate(self, node, idx):
-        _, to_op = build_mutations([node.op], _to_ops)[idx]
+        _, to_op = build_mutations([type(node.op)], _to_ops)[idx]
         node.op = to_op()
         return node

--- a/cosmic_ray/operators/comparison_operator_replacement.py
+++ b/cosmic_ray/operators/comparison_operator_replacement.py
@@ -77,7 +77,7 @@ def _build_mutations(node):
         ops = _rhs_is_none_ops
     else:
         ops = _all_ops
-    return build_mutations(node.ops, ops)
+    return build_mutations(map(type, node.ops), ops)
 
 
 class MutateComparisonOperator(Operator):

--- a/cosmic_ray/operators/comparison_operator_replacement.py
+++ b/cosmic_ray/operators/comparison_operator_replacement.py
@@ -48,7 +48,7 @@ _RHS_IS_NONE_OPS = {
 
 def _rhs_is_none_ops(from_op):
     for key, value in _RHS_IS_NONE_OPS.items():
-        if isinstance(from_op, key):
+        if from_op is key:
             yield from value
             return
 

--- a/cosmic_ray/operators/unary_operator_replacement.py
+++ b/cosmic_ray/operators/unary_operator_replacement.py
@@ -16,11 +16,11 @@ def _to_ops(from_op):
     """
 
     for to_op in OPERATORS:
-        if to_op and isinstance(from_op, ast.Not):
+        if to_op and from_op is ast.Not:
             # 'not' can only be removed but not replaced with
             # '+', '-' or '~' b/c that may lead to strange results
             pass
-        elif isinstance(from_op, ast.UAdd) and (to_op is None):
+        elif from_op is ast.UAdd and to_op is None:
             # '+1' => '1' yields equivalent mutations
             pass
         else:
@@ -36,11 +36,11 @@ class MutateUnaryOperator(Operator):
         """
         return self.visit_mutation_site(
             node,
-            len(build_mutations([node.op], _to_ops)))
+            len(build_mutations([type(node.op)], _to_ops)))
 
     def mutate(self, node, idx):
         "Perform the `idx`th mutation on node."
-        _, to_op = build_mutations([node.op], _to_ops)[idx]
+        _, to_op = build_mutations([type(node.op)], _to_ops)[idx]
         if to_op:
             node.op = to_op()
             return node

--- a/cosmic_ray/util.py
+++ b/cosmic_ray/util.py
@@ -81,28 +81,20 @@ def build_mutations(ops, to_ops):
     Each `idx` is an index into `ops` indicating the operator to be mutated
     from. Each `to-op` is the operator class to be mutated to.
 
-    @ops - a list of operations we want to mutate
-    @to_ops - callable - yields all possible values to mutate to
+    This will never produce mutations from an operator to itself.
+
+    If `to_ops` includes `None` in its output, that means to delete the
+    from-operator.
+
+    Args:
+      ops: A sequence of AST operator classes
+      to_ops: A unary callable which takes a from-operator class and returns an
+        iterable of operator classes (or `None`) to mutate to.
     """
-    # note: mutations to self are excluded.
-    # None is a special mutation meaning to delete the operator!
-    # 1) when to_op is None isinstance(from_op, None) will blow up because
-    #    the second parameter needs to be a class
-    # 2) when to_op != None we do the isinstance() check to figure out
-    #    whether or not to include the operator in the list of possible
-    #    mutations
-    #
-    # The `if to_op is None or isinstance(from_op, to_op)` expression handles
-    # both scenarios very elegantly. First we handle 1) and if this is True
-    # the rest of the expression is not evaluated and None is returned. Else
-    # we're in scenario 2) where the left part of the expression is False so
-    # the right part is evaluated. Since the left part of the expression has
-    # confirmed that to_op != None then we're confident that the isinstance()
-    # method will always work.
     return [(idx, to_op)
             for idx, from_op in enumerate(ops)
             for to_op in to_ops(from_op)
-            if to_op is None or not isinstance(from_op, to_op)]
+            if from_op is not to_op]
 
 
 def compare_ast(node1, node2):

--- a/test/unittests/test_build_mutations.py
+++ b/test/unittests/test_build_mutations.py
@@ -1,0 +1,30 @@
+import ast
+
+from cosmic_ray.util import build_mutations
+
+
+OPERATORS = (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.FloorDiv, ast.Mod,
+             ast.Pow, ast.LShift, ast.RShift, ast.BitOr, ast.BitXor,
+             ast.BitAnd)
+
+
+def to_ops(f):
+    return OPERATORS + (None,)
+
+
+def test_build_mutations_avoids_self_mutations():
+    for idx, to_op in build_mutations(OPERATORS, to_ops):
+        from_op = OPERATORS[idx]
+        assert from_op is not to_op
+
+
+def test_build_mutations_returns_valid_indices():
+    for idx, to_op in build_mutations(OPERATORS, to_ops):
+        assert idx < len(OPERATORS)
+
+
+def test_build_mutations_produces_valid_pairs():
+    for idx, to_op in build_mutations(OPERATORS, to_ops):
+        from_op = OPERATORS[idx]
+        assert from_op in OPERATORS
+        assert to_op in OPERATORS or to_op is None


### PR DESCRIPTION
Soon we'll likely need to generate classes dynamically based on (language) operator pairings. For example, rather than have a single class that handles all binary operator mutation, we'll have one per pairing. I expect to use `build_mutations` as part of this work, so this change is about making `build_mutations` ready for it.

Before, `build_mutations` took a sequence of AST node instances and a sequence of types. This won't be possible when we're generating classes because we won't be doing an AST traversal, i.e. we won't have node instances. 