### PR TITLE
Improved machinery for generating operator-replacement operators.

### DIFF
--- a/cosmic_ray/operators/operator.py
+++ b/cosmic_ray/operators/operator.py
@@ -56,21 +56,34 @@ class Operator(ast.NodeTransformer):
             ', '.join(args))
 
 
-class ReplacementOperator(Operator, metaclass=ABCMeta):
-    """Base class for operators that have a "from-operator" and a "to-operator".
+def _op_name(from_op, to_op):
+    assert from_op or to_op, 'Cannot make replacement operator from None to None'
 
-    This is primarily a mechanism to tell linters that these properties exist.
-    Several of our operators build subclasses dynamically, and they primarily
-    just configure different to/from-ops.
+    if from_op is None:
+        return 'Insert_{}'.format(to_op.__name__)
+    elif to_op is None:
+        return 'Delete_{}'.format(from_op.__name__)
+
+    return '{}_{}'.format(from_op.__name__, to_op.__name__)
+
+
+class ReplacementOperatorMeta(type):
+    """Metaclass for mutation operators that replace Python operators.
+
+    This does a few things:
+
+    - Sets the name of the class object based on the class declaration *and* the from-/to-operators.
+    - Makes the from-/to-operators available as class members.
+    - Adds `Operator` as a base class.
     """
-    @property
-    @abstractmethod
-    def from_op(self):
-        """The operator to mutate from."""
-        pass
+    def __init__(cls, name, bases, namespace, from_op, to_op, **kwargs):
+        super().__init__(name, bases, namespace, **kwargs)
 
-    @property
-    @abstractmethod
-    def to_op(self):
-        """The operator to mutate to."""
-        pass
+    def __new__(cls, name, bases, namespace, from_op, to_op, **kwargs):
+        name = '{}_{}'.format(
+            name,
+            _op_name(from_op, to_op))
+        bases = bases + (Operator,)
+        namespace['from_op'] = from_op
+        namespace['to_op'] = to_op
+        return super().__new__(cls, name, bases, namespace, **kwargs)

--- a/test/unittests/test_operators.py
+++ b/test/unittests/test_operators.py
@@ -9,7 +9,7 @@ from cosmic_ray.operators.comparison_operator_replacement import \
      ReplaceComparisonOperator_Is_IsNot,
      ReplaceComparisonOperator_Gt_Eq)
 from cosmic_ray.operators.unary_operator_replacement import \
-    (ReplaceUnaryOperator_Not_None,
+    (ReplaceUnaryOperator_Delete_Not,
      ReplaceUnaryOperator_USub_UAdd)
 from cosmic_ray.operators.binary_operator_replacement import \
     (ReplaceBinaryOperator_Mult_Add,
@@ -68,7 +68,7 @@ OPERATOR_SAMPLES = [
     (ReplaceComparisonOperator_Gt_Lt, 'if x > y: pass'),
     (ReplaceComparisonOperator_Is_IsNot, 'if x is None: pass'),
     (ReplaceComparisonOperator_Gt_Eq, 'if x > 42: pass'),
-    (ReplaceUnaryOperator_Not_None, 'return not X'),
+    (ReplaceUnaryOperator_Delete_Not, 'return not X'),
     (ReplaceUnaryOperator_USub_UAdd, 'x = -1'),
     (ReplaceBinaryOperator_Mult_Add, 'x * y'),
     (ReplaceBinaryOperator_Sub_Mod, 'x - y'),


### PR DESCRIPTION
The main change here is that the `operator.ReplacementOperator` base class has been replaced by the `operator.ReplacementOperatorMeta` metaclass. This makes the dynamic creation of the various operator-replacement mutation operators look my more normal, i.e. we don't invoke the `type` initializer directly now.

@rob-smallshire I did this after reviewing your "Python Master" chapter on metaclasses, so you should probably review it ;)