### PR TITLE
Reduce ast / run on windows

### DIFF
--- a/cosmic_ray/cli.py
+++ b/cosmic_ray/cli.py
@@ -61,7 +61,7 @@ def handle_baseline(args):
         print(''.join(work_item.data))
         return 2
 
-    return os.EX_OK
+    return 0
 
 
 @dsc.command()
@@ -74,7 +74,7 @@ def handle_new_config(args):
     with open(args['<config-file>'], mode='wt') as handle:
         handle.write(config)
 
-    return os.EX_OK
+    return 0
 
 
 @dsc.command()
@@ -146,7 +146,7 @@ def handle_init(args):
             config,
             timeout)
 
-    return os.EX_OK
+    return 0
 
 
 @dsc.command()
@@ -160,7 +160,7 @@ def handle_config(args):
         config, _ = database.get_config()
         print(json.dumps(config))
 
-    return os.EX_OK
+    return 0
 
 
 @dsc.command()
@@ -176,7 +176,7 @@ def handle_exec(args):
         args.get('<session-file>'))
     cosmic_ray.commands.execute(session_file)
 
-    return os.EX_OK
+    return 0
 
 
 @dsc.command()
@@ -192,7 +192,7 @@ def handle_dump(args):
         for record in database.work_items:
             print(json.dumps(record))
 
-    return os.EX_OK
+    return 0
 
 
 @dsc.command()
@@ -221,7 +221,7 @@ def handle_counts(args):
           sum(itertools.chain(
               *(d.values() for d in counts.values()))))
 
-    return os.EX_OK
+    return 0
 
 
 @dsc.command()
@@ -233,7 +233,7 @@ def handle_test_runners(args):
     assert args
     print('\n'.join(cosmic_ray.plugins.test_runner_names()))
 
-    return os.EX_OK
+    return 0
 
 
 @dsc.command()
@@ -245,7 +245,7 @@ def handle_operators(args):
     assert args
     print('\n'.join(cosmic_ray.plugins.operator_names()))
 
-    return os.EX_OK
+    return 0
 
 
 @dsc.command()
@@ -286,7 +286,7 @@ def handle_worker(args):
 
     sys.stdout.write(json.dumps(work_item))
 
-    return os.EX_OK
+    return 0
 
 
 DOC_TEMPLATE = """{program}
@@ -338,16 +338,16 @@ def main(argv=None):
             exit_at_end=False)
     except docopt.DocoptExit as exc:
         print(exc, file=sys.stderr)
-        return os.EX_USAGE
+        return 64
     except FileNotFoundError as exc:
         print(exc, file=sys.stderr)
-        return os.EX_NOINPUT
+        return 66
     except PermissionError as exc:
         print(exc, file=sys.stderr)
-        return os.EX_NOPERM
+        return 77
     except ConfigError as exc:
         print(exc, file=sys.stderr)
-        return os.EX_CONFIG
+        return 78
 
 
 if __name__ == '__main__':

--- a/test/unittests/test_command_line_processing.py
+++ b/test/unittests/test_command_line_processing.py
@@ -79,17 +79,17 @@ def lobotomize(monkeypatch):
 
 
 def test_invalid_command_line_returns_EX_USAGE():
-    assert cosmic_ray.cli.main(['init', 'foo']) == os.EX_USAGE
+    assert cosmic_ray.cli.main(['init', 'foo']) == 64
 
 
 def test_non_existent_file_returns_EX_NOINPUT():
-    assert cosmic_ray.cli.main(['exec', 'foo.session']) == os.EX_NOINPUT
+    assert cosmic_ray.cli.main(['exec', 'foo.session']) == 66
 
 
 def test_unreadable_file_returns_EX_PERM(tmpdir):
     p = tmpdir.ensure('bogus.session.json')
     p.chmod(stat.S_IRUSR)
-    assert cosmic_ray.cli.main(['exec', str(p.realpath())]) == os.EX_NOPERM
+    assert cosmic_ray.cli.main(['exec', str(p.realpath())]) == 77
 
 
 def test_baseline_failure_returns_2(monkeypatch, local_unittest_config, session_file):
@@ -117,18 +117,18 @@ def test_baseline_success_returns_EX_OK(monkeypatch, local_unittest_config, sess
     monkeypatch.setattr(cosmic_ray.plugins, 'get_test_runner', surviving_mutant)
 
     errcode = cosmic_ray.cli.main(['baseline', local_unittest_config])
-    assert errcode == os.EX_OK
+    assert errcode == 0
 
 
 def test_new_config_success_returns_EX_OK(monkeypatch, config_file):
     monkeypatch.setattr(cosmic_ray.commands, 'new_config', lambda *args: '')
     errcode = cosmic_ray.cli.main(['new-config', config_file])
-    assert errcode == os.EX_OK
+    assert errcode == 0
 
 
 def test_init_with_invalid_baseline_returns_EX_CONFIG(invalid_baseline_config, session_file):
     errcode = cosmic_ray.cli.main(['init', invalid_baseline_config, session_file])
-    assert errcode == os.EX_CONFIG
+    assert errcode == 78
 
 # NOTE: We have integration tests for the happy-path for many commands, so we don't cover them explicitly here.
 
@@ -139,7 +139,7 @@ def test_config_success_returns_EX_OK(lobotomize, local_unittest_config, session
     cfg_stream = io.StringIO()
     with cosmic_ray.util.redirect_stdout(cfg_stream):
         errcode = cosmic_ray.cli.main(['config', session_file])
-    assert errcode == os.EX_OK
+    assert errcode == 0
 
     with open(local_unittest_config, mode='rt') as handle:
         orig_cfg = yaml.load(handle)
@@ -149,23 +149,23 @@ def test_config_success_returns_EX_OK(lobotomize, local_unittest_config, session
 
 def test_dump_success_returns_EX_OK(lobotomize, local_unittest_config, session_file):
     errcode = cosmic_ray.cli.main(['init', local_unittest_config, session_file])
-    assert errcode == os.EX_OK
+    assert errcode == 0
 
     errcode = cosmic_ray.cli.main(['dump', session_file])
-    assert errcode == os.EX_OK
+    assert errcode == 0
 
 
 def test_counts_success_returns_EX_OK(lobotomize, local_unittest_config):
-    assert cosmic_ray.cli.main(['counts', local_unittest_config]) == os.EX_OK
+    assert cosmic_ray.cli.main(['counts', local_unittest_config]) == 0
 
 
 def test_test_runners_success_returns_EX_OK():
-    assert cosmic_ray.cli.main(['test-runners']) == os.EX_OK
+    assert cosmic_ray.cli.main(['test-runners']) == 0
 
 
 def test_operators_success_returns_EX_OK():
-    assert cosmic_ray.cli.main(['operators']) == os.EX_OK
+    assert cosmic_ray.cli.main(['operators']) == 0
 
 
 def test_worker_success_returns_EX_OK(lobotomize, local_unittest_config):
-    assert cosmic_ray.cli.main(['worker', 'some_module', 'remove_decorator', '0', local_unittest_config]) == os.EX_OK
+    assert cosmic_ray.cli.main(['worker', 'some_module', 'remove_decorator', '0', local_unittest_config]) == 0


### PR DESCRIPTION
I had issues running cosmic-ray on windows and hypothesis with these changes (+ one in spor but i did not find upstream of spor so far)

The things i changed are.:
- replaced os.EX constants with hard numbers, as the constants are unix only
- remove annotations from ast, before i did that my tests failed with recursion depth exceeded

The second problem i had on linux with pypy3 5.10 as well.