### PR TITLE
Prevent typing double import

### DIFF
--- a/cosmic_ray/worker.py
+++ b/cosmic_ray/worker.py
@@ -19,7 +19,7 @@ try:
                        # which we shall not do twice... by loading it here,
                        # preserve_modules does not delete it and therefore
                        # fancy stuff happens only once
-except:
+except ImportError:
     pass
 
 from .config import serialize_config

--- a/cosmic_ray/worker.py
+++ b/cosmic_ray/worker.py
@@ -14,6 +14,13 @@ import sys
 import traceback
 
 import astunparse
+try:
+    import typing      # the typing module does some fancy stuff at import time
+                       # which we shall not do twice... by loading it here,
+                       # preserve_modules does not delete it and therefore
+                       # fancy stuff happens only once
+except:
+    pass
 
 from .config import serialize_config
 from .importing import preserve_modules, using_ast


### PR DESCRIPTION
This replaces "Reduce ast / run on windows #358"

The problem i experience is explainable by running the typing.py code twice. 

This is what i think happens.:
typing.py gets executed when the unmodified original test code gets loaded
mutation takes place
the preserve_modules context manager deletes typing from the module list 

the mutated code gets loaded, and runs typing again

From now on, on my system at least isinstance(x, Sequence) will trigger an infinit recursion, if there are not more problems. (Why this is not easily reproducible on mac, i do not know)

The proposed solution is to load typing, so it does not get deleted by preserve_modules.