### PR TITLE
Pytest xdist integration

### DIFF
--- a/cosmic_ray/commands/init.py
+++ b/cosmic_ray/commands/init.py
@@ -61,7 +61,7 @@ def init(modules,
       config: The configuration for the new session.
       timeout: The timeout to apply to the work in the session.
     """
-    operators = tuple(cosmic_ray.plugins.operator_names())
+    operators = cosmic_ray.plugins.operator_names()
     work_db.set_config(
         config=config,
         timeout=timeout)

--- a/cosmic_ray/commands/init.py
+++ b/cosmic_ray/commands/init.py
@@ -61,7 +61,7 @@ def init(modules,
       config: The configuration for the new session.
       timeout: The timeout to apply to the work in the session.
     """
-    operators = cosmic_ray.plugins.operator_names()
+    operators = tuple(cosmic_ray.plugins.operator_names())
     work_db.set_config(
         config=config,
         timeout=timeout)

--- a/cosmic_ray/plugins.py
+++ b/cosmic_ray/plugins.py
@@ -41,8 +41,11 @@ def get_operator(name):
 
 
 def operator_names():
-    """Get an iterable of all operator names."""
-    return (
+    """Get all operator names.
+
+    Returns: A sequence of operator names.
+    """
+    return tuple(
         '{}/{}'.format(provider_name, operator_name)
         for provider_name, provider in OPERATOR_PROVIDERS.items()
         for operator_name in provider)
@@ -62,7 +65,10 @@ def get_test_runner(name, test_args):
 
 
 def test_runner_names():
-    """Get iterable of test-runner plugin names."""
+    """Get all test-runner plugin names.
+
+    Returns: A sequence of test-runner plugin names.
+    """
     return ExtensionManager(
         'cosmic_ray.test_runners',
         on_load_failure_callback=_log_extension_loading_failure,
@@ -84,7 +90,10 @@ def get_interceptor(name):
 
 
 def interceptor_names():
-    """Get an iterable of all interceptor plugin names."""
+    """Get all interceptor plugin names.
+
+    Returns: A sequence of interceptor plugin names.
+    """
     return ExtensionManager(
         'cosmic_ray.interceptors',
         on_load_failure_callback=_log_extension_loading_failure,
@@ -104,7 +113,10 @@ def get_execution_engine(name):
 
 
 def execution_engine_names():
-    """Get iterable of execution-enginer plugin names."""
+    """Get all execution-engine plugin names.
+
+    Returns: A sequence of execution-engine names.
+    """
     return ExtensionManager(
         'cosmic_ray.execution_engines',
         on_load_failure_callback=_log_extension_loading_failure,

--- a/plugins/test-runners/pytest/cosmic_ray_pytest_runner/runner.py
+++ b/plugins/test-runners/pytest/cosmic_ray_pytest_runner/runner.py
@@ -37,7 +37,10 @@ class PytestRunner(TestRunner):
         else:
             args = []
 
+        args.append('-n1')
+
         with StringIO() as stdout:
+            exit_code = None
             with redirect_stdout(stdout):
                 exit_code = pytest.main(args, plugins=[collector])
 
@@ -59,7 +62,7 @@ class PytestRunner(TestRunner):
                                 for r in collector.reports if r.failed])
             if exit_code == 2:
                 return (False, [(repr(r), r.longreprtext)
-                                for r in collector.reports if r.failed])
+                                    for r in collector.reports if r.failed])
             stdout.seek(0)
             output = stdout.read()
             raise TestRunnerFailure('pytest exited non-zero', exit_code, output)

--- a/plugins/test-runners/pytest/setup.py
+++ b/plugins/test-runners/pytest/setup.py
@@ -49,7 +49,7 @@ setup(
     ],
     platforms='any',
     include_package_data=True,
-    install_requires=['pytest>=3.0'],
+    install_requires=['pytest>=3.0', 'pytest-xdist'],
     entry_points={
         'cosmic_ray.test_runners': [
             'pytest = cosmic_ray_pytest_runner.runner:PytestRunner',


### PR DESCRIPTION
I had the follwing issue.:

testing test code that is used for testing code that uses cffi.memmove, i have many cases that trigger memory access faults.

That is not an issue with pytest, as using the xdist plugin and the -n1 parameter, memory access faults are just a new way to fail a test. 

I added pytest-xdist as install dependency and the -n1 flag for pytest in this branch, as it seems to me to  be a reasonable default.

A reasonable alternative would be to use  config options... however i do believe that would be nice to have built in

