### PR TITLE
Exception replacement

### DIFF
--- a/src/cosmic_ray/cloning.py
+++ b/src/cosmic_ray/cloning.py
@@ -162,5 +162,5 @@ __builtins__['{0}'] = {0}
 
 def _install_sitecustomize(venv_path):
     _home_dir, lib_dir, _inc_dir, _bin_dir = virtualenv.path_locations(str(venv_path))
-    with open(Path(lib_dir) / 'site-packages' / 'sitecustomize.py', mode='wt', encoding='utf-8') as sc:
+    with open(str(Path(lib_dir) / 'site-packages' / 'sitecustomize.py'), mode='wt', encoding='utf-8') as sc:
         sc.write(_SITE_CUSTOMIZE)

--- a/src/cosmic_ray/exceptions.py
+++ b/src/cosmic_ray/exceptions.py
@@ -1,0 +1,4 @@
+class CosmicRayTestingException(Exception):
+    """Exception that we use for exception replacement.
+    """
+    pass

--- a/src/cosmic_ray/operators/exception_replacer.py
+++ b/src/cosmic_ray/operators/exception_replacer.py
@@ -1,20 +1,10 @@
 "Implementation of the exception-replacement operator."
 
-import builtins
-
 from parso.python.tree import Name, PythonNode
 
 from .operator import Operator
 
-
-class CosmicRayTestingException(Exception):
-    "A special exception we throw that nobody should be trying to catch."
-
-
-# We inject this into builtins so we can easily replace other exceptions
-# without necessitating the import of other modules.
-setattr(builtins, CosmicRayTestingException.__name__,
-        CosmicRayTestingException)
+from cosmic_ray.exceptions import CosmicRayTestingException
 
 
 class ExceptionReplacer(Operator):
@@ -48,12 +38,12 @@ class ExceptionReplacer(Operator):
     def examples(cls):
         return (
             ('try: raise OSError\nexcept OSError: pass',
-             'try: raise OSError\nexcept CosmicRayTestingException: pass'),
+             'try: raise OSError\nexcept {}: pass'.format(CosmicRayTestingException.__name__)),
             ('try: raise OSError\nexcept (OSError, ValueError): pass',
-             'try: raise OSError\nexcept (OSError, CosmicRayTestingException): pass',
+             'try: raise OSError\nexcept (OSError, {}): pass'.format(CosmicRayTestingException.__name__),
              1),
             ('try: raise OSError\nexcept (OSError, ValueError, KeyError): pass',
-             'try: raise OSError\nexcept (OSError, CosmicRayTestingException, KeyError): pass',
+             'try: raise OSError\nexcept (OSError, {}, KeyError): pass'.format(CosmicRayTestingException.__name__),
              1),
             ('try: pass\nexcept: pass',
              'try: pass\nexcept: pass'),

--- a/src/cosmic_ray/operators/provider.py
+++ b/src/cosmic_ray/operators/provider.py
@@ -4,7 +4,7 @@
 import itertools
 
 from . import (binary_operator_replacement, boolean_replacer, break_continue,
-               comparison_operator_replacement, 
+               comparison_operator_replacement, exception_replacer,
                number_replacer, remove_decorator, unary_operator_replacement,
                zero_iteration_for_loop)
 
@@ -18,7 +18,7 @@ _OPERATORS = {
         boolean_replacer.ReplaceAndWithOr, boolean_replacer.ReplaceOrWithAnd,
         break_continue.ReplaceBreakWithContinue,
         break_continue.ReplaceContinueWithBreak,
-        # exception_replacer.ExceptionReplacer,
+        exception_replacer.ExceptionReplacer,
         number_replacer.NumberReplacer,
         remove_decorator.RemoveDecorator,
         zero_iteration_for_loop.ZeroIterationForLoop))


### PR DESCRIPTION
This re-enables the replace-exception mutation operator.

We now use `sitecustomize.py` to inject our custom exception into testing subprocesses.