### PR TITLE
Exclude modules

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -76,46 +76,29 @@ code. It has the following optional arguments:
 
 -  ``--no-local-import``: Allow importing module from the current
    directory.
--  ``exclude-modules=P``: Exclude modules matching this regex pattern
-   from mutation.
 
-Some packages place the tests within a sub-package of the main one:
+The ``init`` verb use following entries from the configuration file:
 
-::
+- ``[cosmic-ray] exclude-modules = []``: Exclude modules matching those glob
+  patterns from mutation. Use ``glob.glob`` syntax.
 
-    C:\dev\PyErf
-    ¦   .gitignore
-    ¦   .travis.yml
-    ¦   CHANGELOG.md
-    ¦   LICENSE
-    ¦   README.rst
-    ¦   requirements-dev.txt
-    ¦   setup.py
-    ¦
-    +---docs
-    ¦       conf.py
-    ¦       index.rst
-    ¦       make.bat
-    ¦       Makefile
-    ¦
-    +---pyerf
-        ¦   __init__.py
-        ¦   __about__.py
-        ¦   pyerf.py
-        ¦
-        +---tests
-                __init__.py
-                test_pyerf.py
+  Sample for django projects:
+
+  ::
+
+   exclude-modules = ["*/tests/*", "*/migrations/*"]
+
 
 As mentioned in
 `here <#An-important-note-on-separating-tests-and-production-code>`__,
-this can be handled via the ``--exlcuded-modules`` flag. With the
-example above, the command to run would be from the Project directory
-(``C:\dev\PyErf``):
+test directory can be handled via the ``excluded-modules`` option.
+
+The list of files that will be mutate effectively can be show by running
+``cosmic-ray init`` with INFO debug level:
 
 ::
 
-    cosmic-ray init --baseline=2 test_session pyerf --exclude-modules=.*tests.* -- pyerf/tests
+ cosmic-ray init -v INFO
 
 Command: exec
 ~~~~~~~~~~~~~

--- a/src/cosmic_ray/cli.py
+++ b/src/cosmic_ray/cli.py
@@ -9,6 +9,7 @@ import os
 import signal
 import subprocess
 import sys
+from collections import defaultdict
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -103,9 +104,16 @@ def handle_init(args):
 
     config = load_config(config_file)
 
-    modules = set(cosmic_ray.modules.find_modules(Path(config['module-path'])))
+    modules = set(cosmic_ray.modules.find_modules(Path(config['module-path']),
+                                                  config['exclude-modules']))
 
-    log.info('Modules discovered: %s', [m for m in modules])
+    if log.isEnabledFor(logging.INFO):
+        log.info('Modules discovered:')
+        per_dir = defaultdict(list)
+        for m in modules:
+            per_dir[m.parent].append(m.name)
+        for dir, files in per_dir.items():
+            log.info(' - %s: %s', dir, ', '.join(sorted(files)))
 
     db_name = args['<session-file>']
 

--- a/src/cosmic_ray/cli.py
+++ b/src/cosmic_ray/cli.py
@@ -104,8 +104,8 @@ def handle_init(args):
 
     config = load_config(config_file)
 
-    modules = set(cosmic_ray.modules.find_modules(Path(config['module-path']),
-                                                  config['exclude-modules']))
+    modules = cosmic_ray.modules.find_modules(Path(config['module-path']))
+    modules = cosmic_ray.modules.filter_paths(modules, config['exclude-modules'])
 
     if log.isEnabledFor(logging.INFO):
         log.info('Modules discovered:')

--- a/src/cosmic_ray/modules.py
+++ b/src/cosmic_ray/modules.py
@@ -4,17 +4,25 @@ import glob
 from pathlib import Path
 
 
-def find_modules(module_path):
+def find_modules(module_path, excluded_modules):
     """Find all modules in the module (possibly package) represented by `module_path`.
 
     Args:
         module_path: A pathlib.Path to a Python package or module.
+        excluded_modules: List for glob of modules to exclude.
 
     Returns: An iterable of paths Python modules (i.e. *py files).
     """
-    if module_path.is_file():
+    if module_path.is_dir():
+        pyfiles = set(glob.glob('{}/**/*.py'.format(module_path), recursive=True))
+
+    else:
         if module_path.suffix == '.py':
-            yield module_path
-    elif module_path.is_dir():
-        pyfiles = glob.glob('{}/**/*.py'.format(module_path), recursive=True)
-        yield from (Path(pyfile) for pyfile in pyfiles)
+            pyfiles = {module_path}
+        else:
+            pyfiles = set()
+
+    excluded = set(f for excluded_module in excluded_modules
+                   for f in glob.glob(excluded_module, recursive=True))
+
+    yield from (Path(pyfile) for pyfile in pyfiles - excluded)

--- a/src/cosmic_ray/modules.py
+++ b/src/cosmic_ray/modules.py
@@ -4,7 +4,7 @@ import glob
 from pathlib import Path
 
 
-def find_modules(module_path, excluded_modules):
+def find_modules(module_path, excluded_modules=None):
     """Find all modules in the module (possibly package) represented by `module_path`.
 
     Args:
@@ -22,7 +22,9 @@ def find_modules(module_path, excluded_modules):
         else:
             pyfiles = set()
 
-    excluded = set(f for excluded_module in excluded_modules
-                   for f in glob.glob(excluded_module, recursive=True))
+    if excluded_modules:
+        excluded = set(f for excluded_module in excluded_modules
+                       for f in glob.glob(excluded_module, recursive=True))
+        pyfiles = pyfiles - excluded
 
-    yield from (Path(pyfile) for pyfile in pyfiles - excluded)
+    yield from (Path(pyfile) for pyfile in pyfiles)

--- a/src/cosmic_ray/modules.py
+++ b/src/cosmic_ray/modules.py
@@ -12,16 +12,12 @@ def find_modules(module_path):
 
     Returns: An iterable of paths Python modules (i.e. *py files).
     """
-    if module_path.is_dir():
-        pyfiles = glob.glob('{}/**/*.py'.format(module_path), recursive=True)
-
-    else:
+    if module_path.is_file():
         if module_path.suffix == '.py':
-            pyfiles = module_path,
-        else:
-            pyfiles = ()
-
-    yield from (Path(pyfile) for pyfile in pyfiles)
+            yield module_path
+    elif module_path.is_dir():
+        pyfiles = glob.glob('{}/**/*.py'.format(module_path), recursive=True)
+        yield from (Path(pyfile) for pyfile in pyfiles)
 
 
 def filter_paths(paths, excluded_paths):

--- a/src/cosmic_ray/modules.py
+++ b/src/cosmic_ray/modules.py
@@ -4,27 +4,35 @@ import glob
 from pathlib import Path
 
 
-def find_modules(module_path, excluded_modules=None):
+def find_modules(module_path):
     """Find all modules in the module (possibly package) represented by `module_path`.
 
     Args:
         module_path: A pathlib.Path to a Python package or module.
-        excluded_modules: List for glob of modules to exclude.
 
     Returns: An iterable of paths Python modules (i.e. *py files).
     """
     if module_path.is_dir():
-        pyfiles = set(glob.glob('{}/**/*.py'.format(module_path), recursive=True))
+        pyfiles = glob.glob('{}/**/*.py'.format(module_path), recursive=True)
 
     else:
         if module_path.suffix == '.py':
-            pyfiles = {module_path}
+            pyfiles = module_path,
         else:
-            pyfiles = set()
-
-    if excluded_modules:
-        excluded = set(f for excluded_module in excluded_modules
-                       for f in glob.glob(excluded_module, recursive=True))
-        pyfiles = pyfiles - excluded
+            pyfiles = ()
 
     yield from (Path(pyfile) for pyfile in pyfiles)
+
+
+def filter_paths(paths, excluded_paths):
+    """Filter out path matching one of excluded_paths glob
+
+    Args:
+        paths: path to filter.
+        excluded_paths: List for glob of modules to exclude.
+
+    Returns: An iterable of paths Python modules (i.e. *py files).
+    """
+    excluded = set(Path(f) for excluded_path in excluded_paths
+                   for f in glob.glob(excluded_path, recursive=True))
+    return set(paths) - excluded

--- a/tests/test_suite/unittests/test_find_modules.py
+++ b/tests/test_suite/unittests/test_find_modules.py
@@ -1,6 +1,7 @@
 from pathlib import Path
+from unittest import result
 
-from cosmic_ray.modules import find_modules
+from cosmic_ray.modules import find_modules, filter_paths
 
 
 def test_small_directory_tree(data_dir):
@@ -48,20 +49,22 @@ def test_small_directory_tree_with_excluding_files(data_dir):
     paths = (('a', 'b.py'), ('a', 'py.py'),
              ('a', 'c', 'd.py'))
     excluded_modules = ['**/__init__.py']
-    expected = sorted(Path(*path) for path in paths)
+    expected = set(Path(*path) for path in paths)
 
     from cosmic_ray.execution.local import excursion
     with excursion(data_dir):
-        results = sorted(find_modules(Path('a'), excluded_modules))
+        results = find_modules(Path('a'))
+        results = filter_paths(results, excluded_modules)
         assert expected == results
 
 
 def test_small_directory_tree_with_excluding_dir(data_dir):
     paths = (('a', '__init__.py'), ('a', 'b.py'), ('a', 'py.py'))
     excluded_modules = ['*/c/*']
-    expected = sorted(Path(*path) for path in paths)
+    expected = set(Path(*path) for path in paths)
 
     from cosmic_ray.execution.local import excursion
     with excursion(data_dir):
-        results = sorted(find_modules(Path('a'), excluded_modules))
+        results = find_modules(Path('a'))
+        results = filter_paths(results, excluded_modules)
         assert expected == results

--- a/tests/test_suite/unittests/test_find_modules.py
+++ b/tests/test_suite/unittests/test_find_modules.py
@@ -1,7 +1,6 @@
 from pathlib import Path
-from unittest import result
-
 from cosmic_ray.modules import find_modules, filter_paths
+from cosmic_ray.execution.local import excursion
 
 
 def test_small_directory_tree(data_dir):
@@ -51,7 +50,6 @@ def test_small_directory_tree_with_excluding_files(data_dir):
     excluded_modules = ['**/__init__.py']
     expected = set(Path(*path) for path in paths)
 
-    from cosmic_ray.execution.local import excursion
     with excursion(data_dir):
         results = find_modules(Path('a'))
         results = filter_paths(results, excluded_modules)
@@ -63,7 +61,6 @@ def test_small_directory_tree_with_excluding_dir(data_dir):
     excluded_modules = ['*/c/*']
     expected = set(Path(*path) for path in paths)
 
-    from cosmic_ray.execution.local import excursion
     with excursion(data_dir):
         results = find_modules(Path('a'))
         results = filter_paths(results, excluded_modules)

--- a/tests/test_suite/unittests/test_find_modules.py
+++ b/tests/test_suite/unittests/test_find_modules.py
@@ -42,3 +42,26 @@ def test_finding_modules_py_dot_py_using_slashes_with_full_filename(data_dir):
     expected = sorted(data_dir / Path(*path) for path in paths)
     results = sorted(find_modules(data_dir / 'a' / 'py.py'))
     assert expected == results
+
+
+def test_small_directory_tree_with_excluding_files(data_dir):
+    paths = (('a', 'b.py'), ('a', 'py.py'),
+             ('a', 'c', 'd.py'))
+    excluded_modules = ['**/__init__.py']
+    expected = sorted(Path(*path) for path in paths)
+
+    from cosmic_ray.execution.local import excursion
+    with excursion(data_dir):
+        results = sorted(find_modules(Path('a'), excluded_modules))
+        assert expected == results
+
+
+def test_small_directory_tree_with_excluding_dir(data_dir):
+    paths = (('a', '__init__.py'), ('a', 'b.py'), ('a', 'py.py'))
+    excluded_modules = ['*/c/*']
+    expected = sorted(Path(*path) for path in paths)
+
+    from cosmic_ray.execution.local import excursion
+    with excursion(data_dir):
+        results = sorted(find_modules(Path('a'), excluded_modules))
+        assert expected == results

--- a/tests/test_suite/unittests/test_find_modules.py
+++ b/tests/test_suite/unittests/test_find_modules.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from cosmic_ray.modules import find_modules, filter_paths
-from cosmic_ray.execution.local import excursion
 
 
 def test_small_directory_tree(data_dir):
@@ -44,24 +43,24 @@ def test_finding_modules_py_dot_py_using_slashes_with_full_filename(data_dir):
     assert expected == results
 
 
-def test_small_directory_tree_with_excluding_files(data_dir):
+def test_small_directory_tree_with_excluding_files(data_dir, path_utils):
     paths = (('a', 'b.py'), ('a', 'py.py'),
              ('a', 'c', 'd.py'))
     excluded_modules = ['**/__init__.py']
     expected = set(Path(*path) for path in paths)
 
-    with excursion(data_dir):
+    with path_utils.excursion(data_dir):
         results = find_modules(Path('a'))
         results = filter_paths(results, excluded_modules)
         assert expected == results
 
 
-def test_small_directory_tree_with_excluding_dir(data_dir):
+def test_small_directory_tree_with_excluding_dir(data_dir, path_utils):
     paths = (('a', '__init__.py'), ('a', 'b.py'), ('a', 'py.py'))
     excluded_modules = ['*/c/*']
     expected = set(Path(*path) for path in paths)
 
-    with excursion(data_dir):
+    with path_utils.excursion(data_dir):
         results = find_modules(Path('a'))
         results = filter_paths(results, excluded_modules)
         assert expected == results


### PR DESCRIPTION
Implementation of exclude-module

I don't use here interceptor because I don't want to see skipped module in the list of cosmic-ray -v INFO init
