### PR TITLE
Clone without virtualenv

### DIFF
--- a/docs/source/cloning.rst
+++ b/docs/source/cloning.rst
@@ -16,6 +16,37 @@ You can configure cloning in your configuration TOML in the
 `cosmic-ray.cloning` section. At a minimum, you must have a
 `cosmic-ray.cloning.method` entry in your config.
 
+Possible entry into `[cosmic-ray.cloning]` are:
+
+- `workspace_type`
+- `method`
+- `command`
+
+workspace_type
+==============
+
+The `workspace_type` entry is the name of workspace method creation:
+Possible names are:
+
+- `cloned`: Workspace is built by cloning your sources with the `copy` method
+  (see bellow). Useful if your sources can be run in-place.
+- `cloned_with_virtualenv`: Workspace is built by cloning your sources like
+  previous method and create an local virtualenv environment locally.
+  Useful to deploy your sources.
+
+::
+
+ [cosmic-ray.cloning]
+ workspace_type = 'cloned'
+
+This entry is optional. For compatibility reason, the default is
+`cloned_with_virtualenv`.
+
+After This workspace deployent, `command` will be executed (see bellow).
+
+copy
+====
+
 The "copy" cloning method simple copies an entire filesystem directory tree. You can use configure it like
 this::
 

--- a/src/cosmic_ray/commands/new_config.py
+++ b/src/cosmic_ray/commands/new_config.py
@@ -90,6 +90,7 @@ def new_config():
     config['execution-engine']['name'] = menu.show(header="Execution engine", returns="desc")
 
     config["cloning"] = ConfigDict()
+    config['cloning']['workspace_type'] = 'cloned_with_virtualenv'
     config['cloning']['method'] = 'copy'
     config['cloning']['commands'] = []
 

--- a/src/cosmic_ray/config.py
+++ b/src/cosmic_ray/config.py
@@ -107,6 +107,11 @@ class ConfigDict(dict):
         "The 'cloning' section of the config."
         return self['cloning']
 
+    @property
+    def cloning_config_workspace_type(self):
+        "The 'workspace' section of the cloning section"
+        return self.cloning_config.get('workspace_type', 'cloned_with_virtualenv')
+
 
 @contextmanager
 def _config_stream(filename):

--- a/src/cosmic_ray/execution/local.py
+++ b/src/cosmic_ray/execution/local.py
@@ -41,7 +41,8 @@ import multiprocessing
 import multiprocessing.util
 import os
 
-from cosmic_ray.cloning import ClonedWorkspace
+from cosmic_ray.cloning import ClonedWorkspaceWithVirtualenv, Workspace
+from cosmic_ray.config import ConfigDict
 from cosmic_ray.execution.execution_engine import ExecutionEngine
 from cosmic_ray.worker import worker
 
@@ -62,7 +63,7 @@ def excursion(dirname):
         os.chdir(orig)
 
 
-def _initialize_worker(config):
+def _initialize_worker(config: ConfigDict):
     # pylint: disable=global-statement
     global _workspace
     global _config
@@ -72,7 +73,8 @@ def _initialize_worker(config):
     _config = config
 
     log.info('Initialize local-git worker in PID %s', os.getpid())
-    _workspace = ClonedWorkspace(config.cloning_config)
+    _workspace = Workspace.get_workspace(config.cloning_config_workspace_type,
+                                         config.cloning_config)
 
     # Register a finalizer
     multiprocessing.util.Finalize(_workspace, _workspace.cleanup, exitpriority=16)


### PR DESCRIPTION
Create working directory in /tmp without creating virtualenv.
Then we can run tests within current environment (environment where cosmic-ray was launched from).
For this, multiple Workspace classes was created and workspace instantiation is driven with a new parameter [cloning] workspace_type
