### PR TITLE
Operator remove named parameters

### DIFF
--- a/src/cosmic_ray/operators/binary_operator_replacement.py
+++ b/src/cosmic_ray/operators/binary_operator_replacement.py
@@ -54,12 +54,12 @@ def _create_replace_binary_operator(from_op, to_op):
 
 
 # Parent types of operators which indicate that the operator isn't binary.
-_NON_BINARY_PARENTS = set((
+_NON_BINARY_PARENTS = {
     'factor',       # unary operators, e.g. -1
     'argument',     # extended function definitions, e.g. def foo(*args)
     'star_expr',    # destructuring, e.g. a, *b = x
     'import_from',  # star import, e.g. from module import *
-))
+}
 
 
 def _is_binary_operator(node):

--- a/src/cosmic_ray/operators/boolean_replacer.py
+++ b/src/cosmic_ray/operators/boolean_replacer.py
@@ -15,7 +15,7 @@ class ReplaceTrueWithFalse(KeywordReplacementOperator):
 class ReplaceFalseWithTrue(KeywordReplacementOperator):
     """An that replaces False with True."""
     from_keyword = 'False'
-    to_keyword = 'To'
+    to_keyword = 'True'
 
 
 class ReplaceAndWithOr(KeywordReplacementOperator):

--- a/src/cosmic_ray/operators/comparison_operator_replacement.py
+++ b/src/cosmic_ray/operators/comparison_operator_replacement.py
@@ -84,14 +84,14 @@ _RHS_IS_NONE_OPS = {
 }
 
 # This determines the allowed to mutations when the RHS is a number
-_RHS_IS_INTEGER_OPS = set([
+_RHS_IS_INTEGER_OPS = {
     ComparisonOperators.Eq,
     ComparisonOperators.NotEq,
     ComparisonOperators.Lt,
     ComparisonOperators.LtE,
     ComparisonOperators.Gt,
     ComparisonOperators.GtE,
-])
+}
 
 
 def _allowed(to_op, from_op, rhs):

--- a/src/cosmic_ray/operators/keyword_replacer.py
+++ b/src/cosmic_ray/operators/keyword_replacer.py
@@ -10,6 +10,8 @@ from .operator import Operator
 class KeywordReplacementOperator(Operator):
     """A base class for operators that replace one keyword with another
     """
+    from_keyword = None
+    to_keyword = None
 
     def mutation_positions(self, node):
         if isinstance(node, Keyword):

--- a/src/cosmic_ray/operators/operator.py
+++ b/src/cosmic_ray/operators/operator.py
@@ -49,12 +49,12 @@ class Operator(ABC):
         """Examples of the mutations that this operator can make.
 
         This is primarily for testing purposes, but it could also be used for
-        docmentation.
+        documentation.
 
         Each example is a tuple of the form `(from-code, to-code, index)`. The
         `index` is optional and will be assumed to be 0 if it's not included.
         The `from-code` is a string containing some Python code prior to
-        mutation. The `to-code` is a string desribing the code after mutation.
+        mutation. The `to-code` is a string describing the code after mutation.
         `index` indicates the occurrence of the application of the operator to
         the code (i.e. for when an operator can perform multiple mutation to a
         piece of code).

--- a/src/cosmic_ray/operators/provider.py
+++ b/src/cosmic_ray/operators/provider.py
@@ -6,7 +6,7 @@ import itertools
 from . import (binary_operator_replacement, boolean_replacer, break_continue,
                comparison_operator_replacement, exception_replacer,
                number_replacer, remove_decorator, unary_operator_replacement,
-               zero_iteration_for_loop)
+               zero_iteration_for_loop, remove_named_arguments)
 
 _OPERATORS = {
     op.__name__: op
@@ -21,7 +21,9 @@ _OPERATORS = {
         exception_replacer.ExceptionReplacer,
         number_replacer.NumberReplacer,
         remove_decorator.RemoveDecorator,
-        zero_iteration_for_loop.ZeroIterationForLoop))
+        zero_iteration_for_loop.ZeroIterationForLoop,
+        remove_named_arguments.RemoveNamedArguments,
+    ))
 }
 
 

--- a/src/cosmic_ray/operators/remove_named_arguments.py
+++ b/src/cosmic_ray/operators/remove_named_arguments.py
@@ -1,0 +1,46 @@
+"""Remove named arguments
+Remove in function call, named arguments
+
+Because in a lot of vase, named arguments represents options or fields.
+
+The lost of an option or a field must imply application failure.
+
+Examples:
+    - subprocess.Popen call
+    - ORM (like django models)
+"""
+
+from parso.python.tree import PythonNode, Operator as tree_Operator
+from cosmic_ray.operators.operator import Operator
+
+
+class RemoveNamedArguments(Operator):
+    def mutation_positions(self, node):
+        if isinstance(node, PythonNode) and node.type == 'arglist':
+            for child in node.children:
+                if isinstance(child, PythonNode) and child.type == 'argument':
+                    yield child.start_pos, child.end_pos
+
+    def mutate(self, node, index):
+        assert isinstance(node, PythonNode)
+        count = 0
+        for i, child in enumerate(node.children):
+            if isinstance(child, PythonNode) and child.type == 'argument':
+                if count == index:
+                    try:
+                        next_child = node.children[i + 1]
+                        if isinstance(next_child, tree_Operator) and next_child.value == ',':
+                            del node.children[i + 1]
+                    except IndexError:
+                        pass
+                    del node.children[i]
+                    return node
+                count += 1
+
+    @classmethod
+    def examples(cls):
+        return (
+            ("f(1, b=2)", "f(1,)"),  # Ending coma is acceptable
+            ("f(1, b=2, c=3)", "f(1, c=3)"),
+            ("f(a=1, b=2)", "f( b=2)"),
+        )

--- a/src/cosmic_ray/operators/remove_named_arguments.py
+++ b/src/cosmic_ray/operators/remove_named_arguments.py
@@ -9,38 +9,60 @@ Examples:
     - subprocess.Popen call
     - ORM (like django models)
 """
-
-from parso.python.tree import PythonNode, Operator as tree_Operator
+import re
+from parso.python.tree import PythonNode, Operator as tree_Operator, Newline
 from cosmic_ray.operators.operator import Operator
+from cosmic_ray.operators.util import ObjTest
 
 
 class RemoveNamedArguments(Operator):
+    re_skip = re.compile(r'.*pragma:.*mutation-no-remove.*')
+
     def mutation_positions(self, node):
-        if isinstance(node, PythonNode) and node.type == 'arglist':
+        if ObjTest(node).match(PythonNode, type='arglist'):
             for child in node.children:
-                if isinstance(child, PythonNode) and child.type == 'argument':
-                    yield child.start_pos, child.end_pos
+                if ObjTest(child).match(PythonNode, type='argument'):
+                    if not self._do_skip_argument(child):
+                        yield child.start_pos, child.end_pos
+
+    @classmethod
+    def _do_skip_argument(cls, node):
+        # Now we look if there is no # pragma: no-remove on any prefix
+        # before the next newline
+        t = ObjTest(node)
+        while t and not t.match(Newline):
+            t = t.get_next_leaf()
+            prefix = t.prefix.obj
+            if prefix:
+                return cls.re_skip.match(prefix)
+        return False
 
     def mutate(self, node, index):
         assert isinstance(node, PythonNode)
         count = 0
         for i, child in enumerate(node.children):
-            if isinstance(child, PythonNode) and child.type == 'argument':
-                if count == index:
-                    try:
-                        next_child = node.children[i + 1]
-                        if isinstance(next_child, tree_Operator) and next_child.value == ',':
-                            del node.children[i + 1]
-                    except IndexError:
-                        pass
-                    del node.children[i]
-                    return node
-                count += 1
+            if ObjTest(child).match(PythonNode, type='argument'):
+                if not self._do_skip_argument(child):
+                    if count == index:
+                        try:
+                            next_child = node.children[i + 1]
+                            if ObjTest(next_child).match(tree_Operator, value=','):
+                                del node.children[i + 1]
+                        except IndexError:
+                            pass
+                        del node.children[i]
+                        return node
+                    count += 1
 
     @classmethod
     def examples(cls):
         return (
             ("f(1, b=2)", "f(1,)"),  # Ending coma is acceptable
-            ("f(1, b=2, c=3)", "f(1, c=3)"),
-            ("f(a=1, b=2)", "f( b=2)"),
+            ("f(1, b=2, c=3)", "f(1, c=3)", 0),
+            ("f(1, b=2, c=3)", "f(1, b=2,)", 1),
+
+            ("f(a=1, b=2)", "f( b=2)", 0),
+            ("f(a=1, b=2)", "f(a=1,)", 1),
+
+            ("f(a=1, # pragma: mutation-no-remove\n  b=2)", "f(a=1,)", 0),
         )

--- a/src/cosmic_ray/operators/util.py
+++ b/src/cosmic_ray/operators/util.py
@@ -19,3 +19,134 @@ def extend_name(suffix):
         return cls
 
     return dec
+
+
+def dump_node(node, stdout=None):
+    import sys
+    stdout = stdout or sys.stdout
+    write = stdout.write
+
+    def do_dump(node, indent=''):
+        write(f"{indent}{type(node).__name__}({node.type}")
+        value = getattr(node, 'value', None)
+        if value:
+            value = value.replace('\n', '\\n')
+            write(f", '{value}'")
+        children = getattr(node, 'children', None)
+        if children:
+            write(', [\n')
+            for child in children:
+                do_dump(child, indent+' '*4)
+                write(',\n')
+            write(f"{indent}]")
+        write(')')
+        if not indent:
+            write('\n')
+
+    do_dump(node)
+
+
+class ObjTest:
+    """
+    Allowing to navigate into any object and test attribute of any object:
+
+    Examples:
+    >>> ObjTest(node).parent.match(Node, type='node').ok
+
+    Test if node.parent isinstance of Node and node.parent.type == 'node'
+    At each step (each '.' (dot)) you receive an ObjTest object, then
+
+    Navigation:
+    You can call any properties or functions of the base object
+    >>> ObjTest(node).parent.children[2].get_next_sibling()
+
+    Test:
+    >>> ObjTest(node).match(attr='value').match(Class)
+    All in once:
+    >>> ObjTest(node).match(Class, attr='value')
+
+    Conditional navigation:
+    >>> ObjTest(node).IF.match(attr='intermediate').parent.FI
+
+    Final result:
+    >>> ObjTest(node).ok
+    >>> bool(ObjTest(node))
+
+    """
+    def __init__(self, obj):
+        self.obj = obj
+
+    def _clone(self, obj) -> 'ObjTest':
+        return type(self)(obj)
+
+    def match(self, clazz=None, **kwargs) -> 'ObjTest':
+        obj = self.obj
+        if obj is None:
+            return self
+
+        if clazz is None or isinstance(obj, clazz):
+            for k, v in kwargs.items():
+                op = None
+                k__op = k.split('__')
+                if len(k__op) == 2:
+                    k, op = k__op
+                node_value = getattr(obj, k)
+                if op is None:
+                    if node_value != v:
+                        break
+                elif op == 'in':
+                    if node_value not in v:
+                        break
+                else:
+                    raise ValueError("Can't handle operator %s", op)
+            else:
+                # All is true, continue recursion
+                return self
+
+        # A test fails
+        return self._clone(None)
+
+    @property
+    def ok(self):
+        return bool(self.obj)
+
+    def __bool__(self):
+        return self.ok
+
+    def __getattr__(self, item) -> 'ObjTest':
+        obj = self.obj
+        if obj is None:
+            return self
+        return self._clone(getattr(obj, item))
+
+    @property
+    def IF(self):
+        return ObjTestOptionnal(self.obj, obj_test=self)
+
+    def __call__(self, *args, **kwargs) -> 'ObjTest':
+        if self.obj is None:
+            return self
+        return self._clone(self.obj(*args, **kwargs))
+
+    def __getitem__(self, item) -> 'ObjTest':
+        if self.obj is None:
+            return self
+        return self._clone(self.obj[item])
+
+
+class ObjTestOptionnal(ObjTest):
+    def __init__(self, obj, obj_test=None):
+        super().__init__(obj)
+        self._initial = obj_test
+
+    def _clone(self, obj):
+        o = super()._clone(obj)
+        o._initial = self._initial
+        return o
+
+    @property
+    def FI(self):
+        if self:
+            return self._initial._clone(self.obj)
+        else:
+            return self._initial


### PR DESCRIPTION
Remove named parameter from function call

Useful for django model filter for instance.

I added `# pragma: mutation-no-remove` to avoid deletion, because it can be useful to explicit
some parameters with theirs default values to allowing other mutation on its.