### PR TITLE
Integration of pragma filtering during init visit of nodes

### DIFF
--- a/src/cosmic_ray/ast.py
+++ b/src/cosmic_ray/ast.py
@@ -1,9 +1,12 @@
 "Tools for working with parso ASTs."
 
 from abc import ABC, abstractmethod
+from typing import Dict, List
 
 import parso.python.tree
 import parso.tree
+
+from cosmic_ray.pragma import get_pragma_list
 
 
 class Visitor(ABC):
@@ -41,6 +44,37 @@ def get_ast(module_path, python_version):
         source = handle.read()
 
     return parso.parse(source, version=python_version)
+
+
+def get_comment_on_node_line(node) -> str or None:
+    """
+    From a parso node, get the comment on the node line
+    and return the comment
+    """
+
+    # Now we are looking for any non empty prefix before next '\n'
+    while node is not None:
+        node = node.get_next_leaf()
+        if node:
+            # don't strip '\n'
+            prefix = node.prefix.strip(" \t")
+            if prefix:
+                return prefix
+
+        if isinstance(node, parso.python.tree.Newline):
+            return node.prefix
+
+
+def get_node_pragma_categories(node) -> None or Dict[str, None or List[str]]:
+    """
+    Get pragma dictionary `see get_pragma_list` declared on the line
+    of the node
+    """
+    comment = get_comment_on_node_line(node)
+    if comment:
+        return get_pragma_list(comment)
+    else:
+        return None
 
 
 def is_none(node):

--- a/src/cosmic_ray/operators/operator.py
+++ b/src/cosmic_ray/operators/operator.py
@@ -1,6 +1,9 @@
 "Implementation of operator base class."
-
+import re
 from abc import ABC, abstractmethod
+
+
+_re_camel_to_kebab_case = re.compile(r'([a-z0-9])([A-Z])')
 
 
 class Operator(ABC):
@@ -13,11 +16,24 @@ class Operator(ABC):
 
     def __init__(self, python_version):
         self._python_version = python_version
+        self._pragma_category_name = None
 
     @property
     def python_version(self):
         "Python major.minor version as a string."
         return self._python_version
+
+    @property
+    def pragma_category_name(self):
+        if self._pragma_category_name is None:
+            name = type(self).__name__
+            # Removing remove because this is a pragma category name after: 'no mutate'
+            if name.startswith('Remove'):
+                name = name[len('Remove'):]
+            name = _re_camel_to_kebab_case.sub(r'\1-\2', name).lower()
+            self._pragma_category_name = name
+
+        return self._pragma_category_name
 
     @abstractmethod
     def mutation_positions(self, node):
@@ -49,12 +65,12 @@ class Operator(ABC):
         """Examples of the mutations that this operator can make.
 
         This is primarily for testing purposes, but it could also be used for
-        docmentation.
+        documentation.
 
         Each example is a tuple of the form `(from-code, to-code, index)`. The
         `index` is optional and will be assumed to be 0 if it's not included.
         The `from-code` is a string containing some Python code prior to
-        mutation. The `to-code` is a string desribing the code after mutation.
+        mutation. The `to-code` is a string describing the code after mutation.
         `index` indicates the occurrence of the application of the operator to
         the code (i.e. for when an operator can perform multiple mutation to a
         piece of code).

--- a/src/cosmic_ray/pragma.py
+++ b/src/cosmic_ray/pragma.py
@@ -1,0 +1,77 @@
+import re
+from typing import Dict, List
+
+_re_pragma = re.compile(r'([-A-Za-z0-9](?: (?! )|[-A-Za-z0-9])*)(:?)(,?)')
+
+
+def get_pragma_list(line: str) -> None or Dict[str, None or List[str]]:
+    """
+    Pragma syntax:
+    - Any comment can be present before 'pragma:' declaration
+    - You can have multiple pragma family separated with double space
+        (allowing family name having multiple words)
+    - You can declare sections of pragma if the pragma name is followed
+        directly with ':'
+    - Pragma family can have an empty section set if no section is declared
+        after ':'  ex "fam:" or "fam1:  fam2
+    - Section names can have a space (two spaces indicate the end
+        of section list)
+    - Sections are separated with ',', comma directly present after the
+        previous section (no space)
+
+    :return Dictionary of list of sections per pragma family.
+        If a pragma family have no section, the dictionary will returns None
+
+    >>> get_pragma_list("# comment")
+    None
+    >>> get_pragma_list("# comment pragma:")
+    {}
+    >>> get_pragma_list("# comment pragma: x y  z")
+    {'x y': None, 'z': None}
+    >>> get_pragma_list("# comment pragma: x:")
+    {'x': []}
+    >>> get_pragma_list("# comment pragma: x:  y")
+    {'x': [], 'y': None}
+    >>> get_pragma_list("# comment pragma: x y  z: d, e")
+    {'x y': None, 'z': ['d', 'e']}
+    >>> get_pragma_list("# comment pragma: x: a, b, c  y z: d, e")
+    {'x': ['a', 'b', 'c'], 'y z': ['d', 'e']}
+    >>> get_pragma_list("comment pragma: x: a, b, c y  z: d, e")
+    {'x': ['a', 'b', 'c y'], 'z': ['d', 'e']}
+    """
+    split = line.split('pragma:', maxsplit=1)
+    if len(split) == 1:
+        return None
+    pragma_list = split[1]
+
+    pragma = {}
+    family_name = None
+    last_section_pos = None
+    for m in _re_pragma.finditer(pragma_list):
+        elt = m.group(1)
+
+        if family_name and m.start() > last_section_pos + 1:
+            # The element is too far away, a new family is starting
+            family_name = None
+
+        if family_name:
+            # If family_name in progress, add elt as section
+            pragma[family_name].append(elt)
+            if not m.group(3):
+                # If no comma, next will be a key
+                family_name = None
+                last_section_pos = None
+            else:
+                last_section_pos = m.end()
+        else:
+            # No family_name in progress, elt is the family_name
+            if m.group(2):
+                # Followed by ':', next will be a section
+                family_name = elt
+                pragma[family_name] = []
+                last_section_pos = m.end()
+            else:
+                # No ':', this family_name have no section,
+                # next is another family_name
+                pragma[elt] = None
+    return pragma

--- a/src/cosmic_ray/work_item.py
+++ b/src/cosmic_ray/work_item.py
@@ -32,9 +32,9 @@ class WorkResult:
     """
 
     def __init__(self,
-                 worker_outcome,
+                 worker_outcome: WorkerOutcome,
                  output=None,
-                 test_outcome=None,
+                 test_outcome: TestOutcome=None,
                  diff=None):
         if worker_outcome is None:
             raise ValueError('Worker outcome must always have a value.')

--- a/tests/test_suite/unittests/test_pragma.py
+++ b/tests/test_suite/unittests/test_pragma.py
@@ -1,0 +1,20 @@
+from cosmic_ray.pragma import get_pragma_list
+
+
+def test_pragma():
+    r = get_pragma_list("# comment")
+    assert r is None
+    r = get_pragma_list("# comment pragma:")
+    assert r == {}
+    r = get_pragma_list("# comment pragma: x y  z")
+    assert r == {'x y': None, 'z': None}
+    r = get_pragma_list("# comment pragma: x:")
+    assert r == {'x': []}
+    r = get_pragma_list("# comment pragma: x:  y")
+    assert r == {'x': [], 'y': None}
+    r = get_pragma_list("# comment pragma: x y  z: d, e")
+    assert r == {'x y': None, 'z': ['d', 'e']}
+    r = get_pragma_list("# comment pragma: x: a, b, c  y z: d, e")
+    assert r == {'x': ['a', 'b', 'c'], 'y z': ['d', 'e']}
+    r = get_pragma_list("comment pragma: x: a, b, c y  z: d, e")
+    assert r == {'x': ['a', 'b', 'c y'], 'z': ['d', 'e']}


### PR DESCRIPTION
According to @boxed idea for pragma category,
This is an implementation of pragma filtering of any operators at core level (not interceptors).

This implementation get comments directly from parso tree
