### PR TITLE
Speed up the init command

### DIFF
--- a/src/cosmic_ray/commands/init.py
+++ b/src/cosmic_ray/commands/init.py
@@ -65,6 +65,7 @@ def init(module_paths, work_db, config):
     work_db.set_config(config=config)
 
     work_db.clear()
+    work_db.disable_synchronisation()
 
     for module_path in module_paths:
         module_ast = get_ast(
@@ -78,6 +79,7 @@ def init(module_paths, work_db, config):
 
     enabled_interceptors = config.sub('interceptors').get('enabled', ())
     apply_interceptors(work_db, enabled_interceptors, config)
+    work_db.enable_synchronisation()
 
 
 def apply_interceptors(work_db, enabled_interceptors, config):

--- a/src/cosmic_ray/commands/init.py
+++ b/src/cosmic_ray/commands/init.py
@@ -27,21 +27,24 @@ class WorkDBInitVisitor(Visitor):
         self.occurrence = 0
 
     def visit(self, node):
-        for start, stop in self.operator.mutation_positions(node):
-            self._record_work_item(start, stop)
+        self.work_db.add_work_items(
+            self._get_work_item(start, stop)
+            for start, stop in self.operator.mutation_positions(node))
+
         return node
 
-    def _record_work_item(self, start_pos, end_pos):
-        self.work_db.add_work_item(
-            WorkItem(
-                job_id=uuid.uuid4().hex,
-                module_path=str(self.module_path),
-                operator_name=self.op_name,
-                occurrence=self.occurrence,
-                start_pos=start_pos,
-                end_pos=end_pos))
+    def _get_work_item(self, start_pos, end_pos):
+        ret = WorkItem(
+            job_id=uuid.uuid4().hex,
+            module_path=str(self.module_path),
+            operator_name=self.op_name,
+            occurrence=self.occurrence,
+            start_pos=start_pos,
+            end_pos=end_pos)
 
         self.occurrence += 1
+
+        return ret
 
 
 def init(module_paths, work_db, config):

--- a/src/cosmic_ray/work_db.py
+++ b/src/cosmic_ray/work_db.py
@@ -190,6 +190,9 @@ class WorkDB:
 
             self._conn.execute("PRAGMA foreign_keys = 1")
 
+            # journal_mode=WAL is persistent
+            self._conn.execute("PRAGMA journal_mode=WAL")
+
             self._conn.execute('''
             CREATE TABLE IF NOT EXISTS work_items
             (module_path text,

--- a/src/cosmic_ray/work_db.py
+++ b/src/cosmic_ray/work_db.py
@@ -135,6 +135,24 @@ class WorkDB:
             if self._conn.isolation_level:
                 self._conn.execute('END TRANSACTION')
 
+    def disable_synchronisation(self):
+        """Stop committing data to disk for every transaction.
+
+        WARNING: this will cause data corruption in case system crash or power
+        off occurs!
+        """
+        with self._conn:
+            self._conn.execute('PRAGMA SYNCHRONOUS=OFF')
+
+    def enable_synchronisation(self):
+        """Re-enable committing data to disk for every transaction.
+
+        This restores the database to standard configuration with data
+        being written to disk with every transaction.
+        """
+        with self._conn:
+            self._conn.execute('PRAGMA SYNCHRONOUS=FULL')
+
     def clear(self):
         """Clear all work items from the session.
 

--- a/src/cosmic_ray/work_db.py
+++ b/src/cosmic_ray/work_db.py
@@ -115,6 +115,26 @@ class WorkDB:
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 ''', _work_item_to_row(work_item))
 
+    def add_work_items(self, work_items):
+        """Add multiple WorkItems.
+
+        Unlike calling `add_work_item` multiple times, performs all insertions
+        in a single transaction.
+
+        Args:
+          work_items: an iterable of WorkItem.
+        """
+        with self._conn:
+            self._conn.execute('BEGIN TRANSACTION')
+            for w_i in work_items:
+                self._conn.execute(
+                    '''
+                    INSERT INTO work_items
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ''', _work_item_to_row(w_i))
+            if self._conn.isolation_level:
+                self._conn.execute('END TRANSACTION')
+
     def clear(self):
         """Clear all work items from the session.
 


### PR DESCRIPTION
The `cosmic-ray init` command takes a lot of time, but that time is mostly spent on waiting for disk synchronisation, not generation of the actual mutation test cases.

this speeds up init execution from over 5 minutes to around 40s on my SSD (and makes it CPU bound, not disk bound)

the last optimisation is rather extreme ("don't use db synchronisation for initial case creation"), but as I've noted in the commit message, the process is not restartable anyway, so there's little point in strict synchronisation