### PR TITLE
Estimate mutation score by sampling

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -134,6 +134,17 @@ You can also generate a handy HTML report with `cr-html`:
 
     cr-html my_session.sqlite > my_session.html
 
+Or use the ``cr-rate`` command to return error if the survival rate rose above
+a specified value:
+
+::
+
+    cr-rate --fail-over 20.5 my_session.sqlite
+
+.. Tip::
+    ``cr-rate`` can also calculate confidence intervals for the survival rate
+    when the ``cosmic-ray exec`` hasn't finished yet.
+
 A concrete example: running the ``adam`` unittests
 --------------------------------------------------
 

--- a/src/cosmic_ray/tools/survival_rate.py
+++ b/src/cosmic_ray/tools/survival_rate.py
@@ -1,6 +1,7 @@
 "Tool for printing the survival rate in a session."
 
 import math
+import sys
 import docopt
 
 from cosmic_ray.work_db import use_db, WorkDB
@@ -9,7 +10,7 @@ from cosmic_ray.work_db import use_db, WorkDB
 def format_survival_rate():
     """cr-rate
 
-Usage: cr-rate [--estimate] [--confidence <confidence_rate>] <session-file>
+Usage: cr-rate [--estimate] [--confidence <confidence_rate>] [--fail-over <max_value>] <session-file>
 
 Calculate the survival rate of a session.
 
@@ -19,11 +20,16 @@ options:
     --confidence <confidence_rate> Specify the confidence levels for estimates, 95 (%) by
                                    default. 80, 90, 95, 98, 99, 99.5, 99.8 and 99.9 are
                                    supported.
+    --fail-over <max_value>        Exit with a non-zero code if the survival rate is
+                                   larger than <max_value> or the calculated confidence
+                                   interval is above the <max_value> (if --estimate is used).
+                                   Specified as percentage.
 """
     arguments = docopt.docopt(
         format_survival_rate.__doc__, version='cr-rate 1.0')
     show_estimate = arguments['--estimate']
     confidence = arguments['--confidence']
+    fail_over = arguments['--fail-over']
 
     # use integers as keys as equality is not well defined for floats
     # the values are z-values for Standard Normal Probabilities
@@ -53,10 +59,16 @@ options:
     if show_estimate:
         conf_int = math.sqrt(rate * (100-rate) / num_complete) \
                    * z_score * (1 - math.sqrt(num_complete / num_items))
+        min_rate = rate - conf_int
         print('{:.2f} {:.2f} {:.2f}'
-              .format(rate-conf_int, rate, rate+conf_int))
+              .format(min_rate, rate, rate + conf_int))
+
     else:
         print('{:.2f}'.format(rate))
+        min_rate = rate
+
+    if fail_over and min_rate > float(fail_over):
+        sys.exit(1)
 
 
 def survival_rate(work_db):

--- a/src/cosmic_ray/tools/survival_rate.py
+++ b/src/cosmic_ray/tools/survival_rate.py
@@ -1,5 +1,6 @@
 "Tool for printing the survival rate in a session."
 
+import math
 import docopt
 
 from cosmic_ray.work_db import use_db, WorkDB
@@ -8,16 +9,31 @@ from cosmic_ray.work_db import use_db, WorkDB
 def format_survival_rate():
     """cr-rate
 
-    Usage: cr-rate <session-file>
+    Usage: cr-rate --estimate <session-file>
 
     Calculate the survival rate of a session.
+
+    options:
+        --estimate    Print the lower bound, estimate and upper bound of
+                      survival rate
     """
     arguments = docopt.docopt(
         format_survival_rate.__doc__, version='cr-rate 1.0')
+    show_estimate = arguments['--estimate']
+    z_score = 1.96  # for 95% confidence interval
+
     with use_db(arguments['<session-file>'], WorkDB.Mode.open) as db:
         rate = survival_rate(db)
+        num_items = db.num_work_items
+        num_complete = db.num_results
 
-    print('{:.2f}'.format(rate))
+    if show_estimate:
+        conf_int = math.sqrt(rate * (100-rate) / num_complete) \
+                   * z_score * (1 - math.sqrt(num_complete / num_items))
+        print('{:.2f} {:.2f} {:.2f}'
+              .format(rate-conf_int, rate, rate+conf_int))
+    else:
+        print('{:.2f}'.format(rate))
 
 
 def survival_rate(work_db):

--- a/src/cosmic_ray/work_db.py
+++ b/src/cosmic_ray/work_db.py
@@ -201,9 +201,11 @@ class WorkDB:
 
     @property
     def pending_work_items(self):
-        "Iterable of all pending work items."
+        "Iterable of all pending work items. In random order."
         pending = self._conn.execute(
-            "SELECT * FROM work_items WHERE job_id NOT IN (SELECT job_id FROM results)"
+            "SELECT * FROM work_items "
+            "WHERE job_id NOT IN (SELECT job_id FROM results) "
+            "ORDER BY hex(randomblob(16))"
         )
         return (_row_to_work_item(p) for p in pending)
 

--- a/tests/test_suite/unittests/test_work_db.py
+++ b/tests/test_suite/unittests/test_work_db.py
@@ -148,8 +148,28 @@ def test_new_work_items_are_pending(work_db):
     ]
 
     for idx, item in enumerate(items):
-        assert list(work_db.pending_work_items) == items[:idx]
+        assert sorted(list(work_db.pending_work_items), key=repr) \
+                == sorted(items[:idx], key=repr)
         work_db.add_work_item(item)
+
+
+def test_work_items_are_returned_in_random_order(work_db):
+    # estimation of survival rate converges much faster if the jobs are
+    # executed in random order, this test checks that the order is random
+    items = [
+        WorkItem('path_{}'.format(idx), 'operator_{}'.format(idx), idx,
+                 (idx, idx), (idx, idx + 1), 'job_id_{}'.format(idx))
+        for idx in range(10)
+    ]
+    for i in items:
+        work_db.add_work_item(i)
+
+    # ten items can be in 10 factorial different orderings
+    # so probability that all ten of them will have the same ordering is one in
+    # (10!)**9 =~ 3.959e65 (218 bit)
+    draws = (list(work_db.pending_work_items) for _ in range(10))
+    first = next(draws)
+    assert any(first != i for i in draws)
 
 
 def test_adding_result_clears_pending(work_db):
@@ -163,7 +183,8 @@ def test_adding_result_clears_pending(work_db):
         work_db.add_work_item(item)
 
     for idx, item in enumerate(items):
-        assert list(work_db.pending_work_items) == items[idx:]
+        assert sorted(list(work_db.pending_work_items), key=repr) \
+                == sorted(items[idx:], key=repr)
         result = ('job_id_{}'.format(idx),
                   WorkResult(
                       output='data_{}'.format(idx),


### PR DESCRIPTION
Since a non-trivial application will have thousands of mutants, we can execute only some part of it (either based on time or count) and calculate the confidence interval for the estimated mutation score.

Change the runner to execute mutations in random order, extend `cr-rate` with ability to use the estimated mutation score and make it useful for use in CI systems.

fixes #490 