### PR TITLE
Issue 501 - Show Survived Mutant Counts in Reports

### DIFF
--- a/src/cosmic_ray/tools/html.py
+++ b/src/cosmic_ray/tools/html.py
@@ -9,7 +9,7 @@ from yattag import Doc
 
 from cosmic_ray.work_db import WorkDB, use_db
 from cosmic_ray.work_item import TestOutcome
-from cosmic_ray.tools.survival_rate import survival_rate
+from cosmic_ray.tools.survival_rate import kills_count, survival_rate
 
 
 def report_html():
@@ -89,7 +89,8 @@ def _generate_html_report(db, only_completed, skip_success):
                                         text('Complete: {} ({:.2f}%)'.format(
                                             num_complete, num_complete / num_items * 100))
                                     with tag('p'):
-                                        text('Survival rate: {:.2f}%'.format(survival_rate(db)))
+                                        num_killed = kills_count(db)
+                                        text('Survived mutants: {} ({:.2f}%)'.format(num_complete - num_killed, survival_rate(db)))
                                 else:
                                     with tag('p'):
                                         text('No jobs completed')

--- a/src/cosmic_ray/tools/html.py
+++ b/src/cosmic_ray/tools/html.py
@@ -90,7 +90,7 @@ def _generate_html_report(db, only_completed, skip_success):
                                             num_complete, num_complete / num_items * 100))
                                     with tag('p'):
                                         num_killed = kills_count(db)
-                                        text('Survived mutants: {} ({:.2f}%)'.format(num_complete - num_killed, survival_rate(db)))
+                                        text('Surviving mutants: {} ({:.2f}%)'.format(num_complete - num_killed, survival_rate(db)))
                                 else:
                                     with tag('p'):
                                         text('No jobs completed')

--- a/src/cosmic_ray/tools/report.py
+++ b/src/cosmic_ray/tools/report.py
@@ -58,6 +58,6 @@ options:
             print('complete: {} ({:.2f}%)'.format(
                 num_complete, num_complete / num_items * 100))
             num_killed = kills_count(db)
-            print('survived mutants: {} ({:.2f}%)'.format(num_complete - num_killed, survival_rate(db)))
+            print('surviving mutants: {} ({:.2f}%)'.format(num_complete - num_killed, survival_rate(db)))
         else:
             print('no jobs completed')

--- a/src/cosmic_ray/tools/report.py
+++ b/src/cosmic_ray/tools/report.py
@@ -3,7 +3,7 @@
 import docopt
 
 from cosmic_ray.work_db import use_db, WorkDB
-from cosmic_ray.tools.survival_rate import survival_rate
+from cosmic_ray.tools.survival_rate import kills_count, survival_rate
 
 
 def report():
@@ -57,6 +57,7 @@ options:
         if num_complete > 0:
             print('complete: {} ({:.2f}%)'.format(
                 num_complete, num_complete / num_items * 100))
-            print('survival rate: {:.2f}%'.format(survival_rate(db)))
+            num_killed = kills_count(db)
+            print('survived mutants: {} ({:.2f}%)'.format(num_complete - num_killed, survival_rate(db)))
         else:
             print('no jobs completed')

--- a/src/cosmic_ray/tools/survival_rate.py
+++ b/src/cosmic_ray/tools/survival_rate.py
@@ -71,10 +71,14 @@ options:
         sys.exit(1)
 
 
+def kills_count(work_db):
+    return sum(r.is_killed for _, r in work_db.results)
+
+
 def survival_rate(work_db):
-    """Calcuate the survival rate for the results in a WorkDB.
+    """Calculate the survival rate for the results in a WorkDB.
     """
-    kills = sum(r.is_killed for _, r in work_db.results)
+    kills = kills_count(work_db)
     num_results = work_db.num_results
 
     if not num_results:

--- a/src/cosmic_ray/tools/survival_rate.py
+++ b/src/cosmic_ray/tools/survival_rate.py
@@ -72,6 +72,8 @@ options:
 
 
 def kills_count(work_db):
+    """Return the number of killed mutants.
+    """
     return sum(r.is_killed for _, r in work_db.results)
 
 


### PR DESCRIPTION
Without this patch, in both CLI and HTML result, we would only have 'Survival rate', while people may be interested to know the count of survived mutants as well.

### After Applying This Patch

![Screenshot_2020-07-15_at_9_41_42_PM](https://user-images.githubusercontent.com/11539188/87589380-6efb6100-c6e5-11ea-83ea-9e5930f79709.png)

<hr>

![Screenshot_2020-07-15_at_9_41_54_PM](https://user-images.githubusercontent.com/11539188/87589403-791d5f80-c6e5-11ea-8ad8-17038bed8a8a.png)
