### PR TITLE
BugFix: empty 'exclude_operators' results in skipping all operators

### DIFF
--- a/src/cosmic_ray/tools/filters/operators_filter.py
+++ b/src/cosmic_ray/tools/filters/operators_filter.py
@@ -19,6 +19,9 @@ class OperatorsFilter(FilterApp):
         return __doc__
 
     def _skip_filtered(self, work_db, exclude_operators):
+        if not exclude_operators:
+            return
+
         re_exclude_operators = re.compile('|'.join('(:?%s)' % e for e in exclude_operators))
 
         for item in work_db.pending_work_items:

--- a/tests/test_suite/unittests/test_operators_filter.py
+++ b/tests/test_suite/unittests/test_operators_filter.py
@@ -3,8 +3,10 @@ from cosmic_ray.work_item import WorkItem, WorkResult, WorkerOutcome
 
 
 class Data:
-    count = 0
-    results = []
+
+    def __init__(self):
+        self.count = 0
+        self.results = []
 
     def new_work_item(self, operator_name, job_id):
         self.count += 1
@@ -35,7 +37,7 @@ class Data:
         self.results.append((job_id, work_result.worker_outcome))
 
     @property
-    def expected(self):
+    def expected_after_filter(self):
         return [
             ("id1", WorkerOutcome.SKIPPED),
             ("id2", WorkerOutcome.SKIPPED),
@@ -45,6 +47,20 @@ class Data:
             ("regex4", WorkerOutcome.SKIPPED),
         ]
 
+    @property
+    def expected_all_filtered(self):
+        return [
+            ("id1", WorkerOutcome.SKIPPED),
+            ("id2", WorkerOutcome.SKIPPED),
+            ("id3", WorkerOutcome.SKIPPED),
+            ("id4", WorkerOutcome.SKIPPED),
+            ("regex1", WorkerOutcome.SKIPPED),
+            ("regex2", WorkerOutcome.SKIPPED),
+            ("regex3", WorkerOutcome.SKIPPED),
+            ("regex4", WorkerOutcome.SKIPPED),
+            ("regex5", WorkerOutcome.SKIPPED),
+        ]
+
 
 def test_operators_filter():
     data = Data()
@@ -52,4 +68,18 @@ def test_operators_filter():
         'Op1', 'Op2', 'Opregex[12]', r'(?:.[oO]m(?:p|P)lex).*'
     ]
     operators_filter.OperatorsFilter()._skip_filtered(data, exclude)
-    assert data.results == data.expected
+    assert data.results == data.expected_after_filter
+
+
+def test_operators_filter_empty_excludes():
+    data = Data()
+    exclude = []
+    operators_filter.OperatorsFilter()._skip_filtered(data, exclude)
+    assert data.results == []
+
+
+def test_operators_filter_all_excluded():
+    data = Data()
+    exclude = [r"."]
+    operators_filter.OperatorsFilter()._skip_filtered(data, exclude)
+    assert data.results == data.expected_all_filtered


### PR DESCRIPTION
WithOUT this patch, if a user (by accident) provides an empty `exclude-operators` in the configuration then applies command `cr-filter-operators`, it will results in that ALL operators to be skipped, while it should not skip any operators.

It's easy to check & confirm this bug:

```python
import re
exclude_operators = []
re_exclude_operators = re.compile('|'.join('(:?%s)' % e for e in exclude_operators))
assert re_exclude_operators.match("abc")
assert re_exclude_operators.match("xyz")
```

Tests are updated/added.