### PR TITLE
Fix configuration loading for OperatorsFilter

### DIFF
--- a/src/cosmic_ray/tools/filters/operators_filter.py
+++ b/src/cosmic_ray/tools/filters/operators_filter.py
@@ -50,7 +50,7 @@ class OperatorsFilter(FilterApp):
         else:
             config = load_config(args.config)
 
-        exclude_operators = config.sub('filters', 'operators-filter').get('exclude-operators', ())
+        exclude_operators = config.sub('operators-filter').get('exclude-operators', ())
         self._skip_filtered(work_db, exclude_operators)
 
     def add_args(self, parser):


### PR DESCRIPTION
I may be wrong, but based on
- logics in https://github.com/sixty-north/cosmic-ray/blob/master/src/cosmic_ray/config.py
- sample TOML in documentation https://cosmic-ray.readthedocs.io/en/latest/filters.html#cr-filter-operators

here we should have `config.sub('operators-filter')` rather than `config.sub('filters', 'operators-filter')`.


## Code to Reproduce & Check
If I save the sample configuration TOML in the [documentation](https://cosmic-ray.readthedocs.io/en/latest/filters.html#cr-filter-operators) as `config.toml`, then I run code below
```python
from cosmic_ray.config import load_config
load_config('config.toml').sub('filters', 'operators-filter')
```

I got `{}`.

Instead, if I change to 

```python
load_config("config.toml").sub('operators-filter')
```

I got expected result
```
{'exclude-operators': ['core/ReplaceComparisonOperator_Is(Not)?_(Not)?(Eq|[LG]tE?)', 'core/ReplaceComparisonOperator_(Not)?(Eq|[LG]tE?)_Is(Not)?', 'core/ReplaceComparisonOperator_[LG]tE_Eq', 'core/ReplaceComparisonOperator_[LG]t_NotEq']}
```
