### PR TITLE
Issue #525 - Fixing excluded-modules

### DIFF
--- a/docs/source/tutorials/intro/index.rst
+++ b/docs/source/tutorials/intro/index.rst
@@ -153,7 +153,8 @@ Next, line 4 tells Cosmic Ray which modules to exclude from mutation:
     :language: toml
 
 In this case we're not excluding any, but there may be times when you need to skip certain modules, e.g. because 
-you know that you don't have sufficient tests for them at the moment.
+you know that you don't have sufficient tests for them at the moment. This parameter expects glob-patterns, so to exclude
+files that end with ``_test.py`` recursively for example, you would add ``"**/*_test.py"``.
 
 Line 5 is one of the most critical lines in the configuration. This tells Cosmic Ray how to run your test suite:
 

--- a/src/cosmic_ray/cli.py
+++ b/src/cosmic_ray/cli.py
@@ -86,7 +86,7 @@ def init(config_file, session_file):
     cfg = load_config(config_file)
 
     modules = cosmic_ray.modules.find_modules(Path(cfg["module-path"]))
-    modules = cosmic_ray.modules.filter_paths(modules, cfg.get("exclude-modules", ()))
+    modules = cosmic_ray.modules.filter_paths(modules, cfg.get("excluded-modules", ()))
 
     if log.isEnabledFor(logging.INFO):
         log.info("Modules discovered:")


### PR DESCRIPTION
Updated the cli.py file to have the correct reference to excluded-modules and updated the docs to include a brief example of how to use the excluded-modules.

Solves https://github.com/sixty-north/cosmic-ray/issues/525