### PR TITLE
Make except statment lists work with just one item

### DIFF
--- a/src/cosmic_ray/operators/exception_replacer.py
+++ b/src/cosmic_ray/operators/exception_replacer.py
@@ -31,6 +31,8 @@ class ExceptionReplacer(Operator):
 
         atom = node.children[1]
         test_list = atom.children[1]
+        if isinstance(test_list, Name):
+            return (test_list,)
         return test_list.children[::2]
 
     @classmethod
@@ -39,6 +41,10 @@ class ExceptionReplacer(Operator):
             Example(
                 "try: raise OSError\nexcept OSError: pass",
                 "try: raise OSError\nexcept {}: pass".format(CosmicRayTestingException.__name__),
+            ),
+            Example(
+                "try: raise OSError\nexcept (OSError): pass",
+                "try: raise OSError\nexcept ({}): pass".format(CosmicRayTestingException.__name__),
             ),
             Example(
                 "try: raise OSError\nexcept (OSError, ValueError): pass",


### PR DESCRIPTION
Without this patch "except (OSError):" leads to an AttributeError. This patch handles this specific example where test_list is an instance of Name.

The tests that already fail (probably since e02b8ec484f00757271e41ac1112a1a599559cb2) still fail, but the added test succeeds.