### PR TITLE
Allow module-path configuration to contain multiple paths

### DIFF
--- a/docs/source/tutorials/intro/index.rst
+++ b/docs/source/tutorials/intro/index.rst
@@ -136,6 +136,8 @@ refers to a single top-level module that will be mutated, and in this case we're
 
     When working on a package, Cosmic Ray will apply mutations to all submodules in the package.
 
+    Additionally, the 'module-path' can be a list of directories or files: `module-path = ["file1.py", "some_directory"]`
+
 Line 3 tells Cosmic Ray the maximium amount of time to let a test run before it's considered a failure:
 
 .. literalinclude:: tutorial.toml.1

--- a/src/cosmic_ray/cli.py
+++ b/src/cosmic_ray/cli.py
@@ -85,7 +85,9 @@ def init(config_file, session_file):
     """
     cfg = load_config(config_file)
     operators_cfg = cfg.operators_config
-    modules = cosmic_ray.modules.find_modules(Path(cfg["module-path"]))
+
+    module_paths = [Path(cfg["module-path"])] if isinstance(cfg["module-path"], str) else map(Path, cfg["module-path"])
+    modules = cosmic_ray.modules.find_modules(module_paths)
     modules = cosmic_ray.modules.filter_paths(modules, cfg.get("excluded-modules", ()))
 
     if log.isEnabledFor(logging.INFO):

--- a/src/cosmic_ray/modules.py
+++ b/src/cosmic_ray/modules.py
@@ -4,21 +4,22 @@ import glob
 from pathlib import Path
 
 
-def find_modules(module_path):
+def find_modules(module_paths):
     """Find all modules in the module (possibly package) represented by ``module_path``.
 
     Args:
-        module_path: A pathlib.Path to a Python package or module.
+        module_paths: A list of pathlib.Path to Python packages or modules.
 
     Returns:
         An iterable of paths Python modules (i.e. \\*py files).
     """
-    if module_path.is_file():
-        if module_path.suffix == ".py":
-            yield module_path
-    elif module_path.is_dir():
-        pyfiles = glob.glob("{}/**/*.py".format(module_path), recursive=True)
-        yield from (Path(pyfile) for pyfile in pyfiles)
+    for module_path in module_paths:
+        if module_path.is_file():
+            if module_path.suffix == ".py":
+                yield module_path
+        elif module_path.is_dir():
+            pyfiles = glob.glob("{}/**/*.py".format(module_path), recursive=True)
+            yield from (Path(pyfile) for pyfile in pyfiles)
 
 
 def filter_paths(paths, excluded_paths):

--- a/tests/unittests/test_find_modules.py
+++ b/tests/unittests/test_find_modules.py
@@ -6,40 +6,40 @@ def test_small_directory_tree(data_dir):
     paths = (('a', '__init__.py'), ('a', 'b.py'), ('a', 'py.py'),
              ('a', 'c', '__init__.py'), ('a', 'c', 'd.py'))
     expected = sorted(data_dir / Path(*path) for path in paths)
-    results = sorted(find_modules(data_dir / 'a'))
+    results = sorted(find_modules([data_dir / 'a']))
     assert expected == results
 
 
 def test_finding_modules_via_dir_name(data_dir):
     paths = (('a', 'c', '__init__.py'), ('a', 'c', 'd.py'))
     expected = sorted(data_dir / Path(*path) for path in paths)
-    results = sorted(find_modules(data_dir / 'a' / 'c'))
+    results = sorted(find_modules([data_dir / 'a' / 'c']))
     assert expected == results
 
 
 def test_finding_modules_via_dir_name_and_filename_ending_in_py(data_dir):
     paths = (('a', 'c', 'd.py'), )
     expected = sorted(data_dir / Path(*path) for path in paths)
-    results = sorted(find_modules(data_dir / 'a' / 'c' / 'd.py'))
+    results = sorted(find_modules([data_dir / 'a' / 'c' / 'd.py']))
     assert expected == results
 
 
 def test_finding_module_py_dot_py_using_dots(data_dir):
     paths = (('a', 'py.py'), )
     expected = sorted(data_dir / Path(*path) for path in paths)
-    results = sorted(find_modules(data_dir / 'a' / 'py.py'))
+    results = sorted(find_modules([data_dir / 'a' / 'py.py']))
     assert expected == results
 
 
 def test_finding_modules_py_dot_py_using_slashes(data_dir):
-    results = sorted(find_modules(data_dir / 'a' / 'py'))
+    results = sorted(find_modules([data_dir / 'a' / 'py']))
     assert [] == results
 
 
 def test_finding_modules_py_dot_py_using_slashes_with_full_filename(data_dir):
     paths = (('a', 'py.py'), )
     expected = sorted(data_dir / Path(*path) for path in paths)
-    results = sorted(find_modules(data_dir / 'a' / 'py.py'))
+    results = sorted(find_modules([data_dir / 'a' / 'py.py']))
     assert expected == results
 
 
@@ -50,7 +50,7 @@ def test_small_directory_tree_with_excluding_files(data_dir, path_utils):
     expected = set(Path(*path) for path in paths)
 
     with path_utils.excursion(data_dir):
-        results = find_modules(Path('a'))
+        results = find_modules([Path('a')])
         results = filter_paths(results, excluded_modules)
         assert expected == results
 
@@ -61,6 +61,13 @@ def test_small_directory_tree_with_excluding_dir(data_dir, path_utils):
     expected = set(Path(*path) for path in paths)
 
     with path_utils.excursion(data_dir):
-        results = find_modules(Path('a'))
+        results = find_modules([Path('a')])
         results = filter_paths(results, excluded_modules)
         assert expected == results
+
+
+def test_multiple_module_paths(data_dir):
+    paths = (('a', 'b.py'), ('a', 'c', '__init__.py'), ('a', 'c', 'd.py'))
+    expected = sorted(data_dir / Path(*path) for path in paths)
+    results = sorted(find_modules([data_dir / 'a' / 'b.py', data_dir / 'a' / 'c']))
+    assert expected == results


### PR DESCRIPTION
I had to estimate how many mutants survive in a huge project where around 400'000 mutations were found. For this I've randomly selected tests and only wanted to mutate the targets of those tests. With the `excluded-modules` this would have been a lot of work. For that I've adapted the code to allow `module-path` to be a list of paths, which will be used as mutation targets.

Since I've already done the work I thought you might be interested in it. If not feel free to discard this PR :)

Additionally, I would expect the tool to abort if the `module-path` is not found and not just do nothing. For an example see: https://github.com/sixty-north/cosmic-ray/blob/e5e0e3b4626da101975fa9ce2be3ce50966c97d2/tests/unittests/test_find_modules.py#L34-L36

Since this changes the behaviour I didn't want to just include it, but if you agree I can also add a commit that checks that the file/folder exists.