### PR TITLE
Verify that the module paths exist

### DIFF
--- a/src/cosmic_ray/modules.py
+++ b/src/cosmic_ray/modules.py
@@ -14,6 +14,8 @@ def find_modules(module_paths):
         An iterable of paths Python modules (i.e. \\*py files).
     """
     for module_path in module_paths:
+        if not module_path.exists():
+            raise FileNotFoundError("Could not find module path {}".format(module_path))
         if module_path.is_file():
             if module_path.suffix == ".py":
                 yield module_path

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import subprocess
 import sys
@@ -81,3 +82,18 @@ def test_empty___init__(example_project_root, session):
     with use_db(str(session_path), WorkDB.Mode.open) as work_db:
         rate = survival_rate(work_db)
         assert rate == 0.0
+
+
+def test_inexisting(example_project_root, session):
+    config = "cosmic-ray.inexisting.conf"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "cosmic_ray.cli", "init", config, str(session)],
+        cwd=str(example_project_root),
+        encoding="utf-8",
+        capture_output=True,
+    )
+
+    assert result.returncode == 66
+    assert result.stdout == ""
+    assert result.stderr == "Could not find module path example/unknown_file.py" + os.linesep

--- a/tests/resources/example_project/cosmic-ray.inexisting.conf
+++ b/tests/resources/example_project/cosmic-ray.inexisting.conf
@@ -1,0 +1,6 @@
+[cosmic-ray]
+module-path = "example/unknown_file.py"
+timeout = 10
+excluded-modules = []
+test-command = "python -m unittest discover tests"
+distributor.name = "local"

--- a/tests/unittests/test_find_modules.py
+++ b/tests/unittests/test_find_modules.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+
+import pytest
 from cosmic_ray.modules import find_modules, filter_paths
 
 
@@ -31,9 +33,11 @@ def test_finding_module_py_dot_py_using_dots(data_dir):
     assert expected == results
 
 
-def test_finding_modules_py_dot_py_using_slashes(data_dir):
-    results = sorted(find_modules([data_dir / 'a' / 'py']))
-    assert [] == results
+def test_finding_modules_with_missing_file(data_dir):
+    path = data_dir / 'a' / 'inexisting_file.py'
+    with pytest.raises(FileNotFoundError) as exc_info:
+        tuple(find_modules((data_dir / 'a', path, data_dir / 'a' / 'c')))
+    assert str(exc_info.value) == "Could not find module path {}".format(path)
 
 
 def test_finding_modules_py_dot_py_using_slashes_with_full_filename(data_dir):


### PR DESCRIPTION
As mentioned in #533, I'm providing a patch so that the module paths are verified to exist.

An example output of an init command where the module path (`some_inexisting_file` in this case) does not exist:

```bash
$ cosmic-ray init cosmic-ray.toml cosmic-ray.sqlite                                                        
Could not find module path some_inexisting_file
```