### PR TITLE
cr-filter-git: mark all as skipped in single transaction

### DIFF
--- a/src/cosmic_ray/tools/filters/git.py
+++ b/src/cosmic_ray/tools/filters/git.py
@@ -45,6 +45,8 @@ class GitFilter(FilterApp):
     def _skip_filtered(self, work_db, branch):
         git_news = self._git_news(branch)
 
+        job_ids = []
+
         for item in work_db.pending_work_items:
             for mutation in item.mutations:
                 if mutation.module_path not in git_news or not (
@@ -60,13 +62,16 @@ class GitFilter(FilterApp):
                         mutation.end_pos,
                     )
 
-                    work_db.set_result(
-                        item.job_id,
-                        WorkResult(
-                            output="Filtered git",
-                            worker_outcome=WorkerOutcome.SKIPPED,
-                        ),
-                    )
+                    job_ids.append(item.job_id)
+
+        if job_ids:
+            work_db.set_multiple_results(
+                job_ids,
+                WorkResult(
+                    output="Filtered git",
+                    worker_outcome=WorkerOutcome.SKIPPED,
+                ),
+            )
 
     def filter(self, work_db: WorkDB, args: Namespace):
         """Mark as skipped all work item that is not new"""

--- a/src/cosmic_ray/work_db.py
+++ b/src/cosmic_ray/work_db.py
@@ -140,6 +140,26 @@ class WorkDB:
         except IntegrityError:
             raise KeyError("Unable to add results for job-id {}. No matching WorkItem.".format(job_id))
 
+    def set_multiple_results(self, job_ids, result):
+        """Set the result for all job IDs.
+
+        This will overwrite any existing results for the jobs.
+
+        Args:
+          job_id: The IDs of the WorkItem to set the results for.
+          result: A WorkResult indicating the result of the job.
+
+        Raises:
+           KeyError: If there is no work-item with a matching job-id.
+        """
+        try:
+            with self._session_maker.begin() as session:
+                for job_id in job_ids:
+                    storage = _work_result_to_storage(result, job_id)
+                    session.merge(storage)
+        except IntegrityError:
+            raise KeyError("Unable to add results for job-id {}. No matching WorkItem.".format(job_id))
+
     @property
     def pending_work_items(self):
         "Iterable of all pending work items. In random order."


### PR DESCRIPTION
Because every skipped transaction is committed individually to the DB, it takes extensive amount of time for a database with few tens of thousands of mutants:

without the patch:
```
18.08user 3.50system 1:12.85elapsed 29%CPU (0avgtext+0avgdata 116220maxresident)k
0inputs+1014816outputs (0major+27993minor)pagefaults 0swaps
```

with this patch:
```
10.33user 0.18system 0:10.55elapsed 99%CPU (0avgtext+0avgdata 116008maxresident)k
0inputs+3176outputs (0major+27989minor)pagefaults 0swaps
```

And this is with a fairly fast NVME SSD, slower disk storage will take extensively more time.