### PR TITLE
cr-rate: don't crash with no executed and --estimate specified

### DIFF
--- a/src/cosmic_ray/tools/survival_rate.py
+++ b/src/cosmic_ray/tools/survival_rate.py
@@ -42,7 +42,10 @@ def format_survival_rate(estimate, confidence, fail_over, session_file):
         num_complete = db.num_results
 
     if estimate:
-        conf_int = math.sqrt(rate * (100 - rate) / num_complete) * z_score * (1 - math.sqrt(num_complete / num_items))
+        if not num_complete:
+            conf_int = 0
+        else:
+            conf_int = math.sqrt(rate * (100 - rate) / num_complete) * z_score * (1 - math.sqrt(num_complete / num_items))
         min_rate = rate - conf_int
         print("{:.2f} {:.2f} {:.2f}".format(min_rate, rate, rate + conf_int))
 


### PR DESCRIPTION
When using the `cr-rate` in CI, and running tests only for the changed lines, when a PR changes only documentation, the `cr-rate` tool will crash when it's used with the `--estimate` option.

This fixes the issue.