### PR TITLE
Add support for higher-order mutants

### DIFF
--- a/docs/source/reference/commands.rst
+++ b/docs/source/reference/commands.rst
@@ -88,6 +88,16 @@ The ``init`` verb use following entries from the configuration file:
   ::
 
    excluded-modules = ["*/tests/*", "*/migrations/*"]
+   
+- ``[cosmic-ray] mutation-order = 1``: Specify the order of mutations to apply.
+  The default value is 1, which means only first-order mutants will be created.
+  Higher values will create higher-order mutants by applying multiple mutations
+  in a single test run. For example, a value of 2 will create both first-order and
+  second-order mutants.
+
+  ::
+
+   mutation-order = 2
 
 
 As mentioned in

--- a/src/cosmic_ray/cli.py
+++ b/src/cosmic_ray/cli.py
@@ -101,7 +101,7 @@ def init(config_file, session_file, force):
             log.error("Session file already contains results. Use --force to overwrite.")
             sys.exit(ExitCode.DATA_ERR)
 
-        cosmic_ray.commands.init(modules, database, operators_cfg)
+        cosmic_ray.commands.init(modules, database, operators_cfg, cfg)
 
     sys.exit(ExitCode.OK)
 
@@ -151,7 +151,7 @@ def baseline(config_file, session_file):
             db.clear()
             db.add_work_item(
                 WorkItem(
-                    mutations=[],
+                    mutations=(),  # Empty tuple to explicitly indicate no mutations
                     job_id="baseline",
                 )
             )
@@ -255,20 +255,64 @@ def http_worker(port, path):
 @click.argument("occurrence", type=int)
 @click.argument("test_command")
 @click.option("--keep-stdout", default=False, flag_value=True, help="Do not squelch output.")
-def mutate_and_test(module_path, operator, occurrence, test_command, keep_stdout):
-    """Run a worker process which performs a single mutation and test run.
-    Each worker does a minimal, isolated chunk of work: it mutates the
+@click.option("--second-mutation", type=str, help="Optional second mutation in format 'module:operator:occurrence'")
+@click.option("--third-mutation", type=str, help="Optional third mutation in format 'module:operator:occurrence'")
+def mutate_and_test(module_path, operator, occurrence, test_command, keep_stdout, second_mutation, third_mutation):
+    """Run a worker process which performs mutation(s) and a test run.
+    
+    By default, this creates a first-order mutant by mutating the
     <occurrence>-th instance of <operator> in <module-path>, runs the test
-    suite defined in the configuration, prints the results, and exits.
+    suite, prints the results, and exits.
+    
+    For higher-order mutants, you can specify additional mutations with the
+    --second-mutation and --third-mutation options. These take values in
+    the format 'module:operator:occurrence'.
 
     Normally you won't run this directly. Rather, it will be launched
-    by an distributor. However, it can be useful to run this on
+    by a distributor. However, it can be useful to run this on
     its own for testing and debugging purposes.
     """
+    from cosmic_ray.work_item import MutationSpec
+    
+    # Create list to hold mutations
+    mutations = []
+    
+    # Add primary mutation
+    mutations.append(MutationSpec(
+        module_path=Path(module_path),
+        operator_name=operator,
+        occurrence=occurrence,
+        start_pos=(0, 0),  # These will be set by the operator
+        end_pos=(0, 0),    # These will be set by the operator
+    ))
+    
+    # Add secondary mutations if specified
+    for mutation_str in [second_mutation, third_mutation]:
+        if mutation_str:
+            parts = mutation_str.split(':')
+            if len(parts) != 3:
+                log.error("Additional mutation must be in format 'module:operator:occurrence'")
+                sys.exit(ExitCode.DATA_ERR)
+                
+            m_module, m_operator, m_occurrence = parts
+            try:
+                m_occurrence = int(m_occurrence)
+            except ValueError:
+                log.error("Occurrence must be an integer")
+                sys.exit(ExitCode.DATA_ERR)
+                
+            mutations.append(MutationSpec(
+                module_path=Path(m_module),
+                operator_name=m_operator,
+                occurrence=m_occurrence,
+                start_pos=(0, 0),  # These will be set by the operator
+                end_pos=(0, 0),    # These will be set by the operator
+            ))
+    
     with open(os.devnull, "w") as devnull:
         with redirect_stdout(sys.stdout if keep_stdout else devnull):
             work_result = cosmic_ray.mutating.mutate_and_test(
-                Path(module_path), operator, occurrence, test_command, None
+                mutations, test_command, None
             )
 
     sys.stdout.write(json.dumps(dataclasses.asdict(work_result)))

--- a/src/cosmic_ray/commands/new_config.py
+++ b/src/cosmic_ray/commands/new_config.py
@@ -40,6 +40,15 @@ def new_config():
     )
     config["timeout"] = float(timeout)
     config["excluded-modules"] = []
+    
+    mutation_order = qprompt.ask_str(
+        "Mutation order (default: 1)",
+        vld=lambda x: int(x) > 0,
+        dflt="1",
+        blk=False,
+        hlp="The maximum number of mutations to apply in a single test run. 1 means only first-order mutants, higher values enable higher-order mutants.",
+    )
+    config["mutation-order"] = int(mutation_order)
 
     config["test-command"] = qprompt.ask_str("Test command", blk=False, hlp=TEST_COMMAND_HELP)
 

--- a/src/cosmic_ray/config.py
+++ b/src/cosmic_ray/config.py
@@ -98,6 +98,15 @@ class ConfigDict(dict):
         parameterization.
         """
         return self.get("operators", {})
+        
+    @property
+    def mutation_order(self):
+        """The order of mutations to apply (how many mutations per work item).
+        
+        If not specified or set to 1, only first-order mutants will be created.
+        Higher values result in applying multiple mutations in a single test run.
+        """
+        return int(self.get("mutation-order", 1))
 
 
 @contextmanager

--- a/src/cosmic_ray/work_db.py
+++ b/src/cosmic_ray/work_db.py
@@ -222,6 +222,8 @@ class MutationSpecStorage(Base):
     "Database model for MutationSpecs"
 
     __tablename__ = "mutation_specs"
+    # Add an id as primary key to allow multiple mutations per job
+    id = Column(Integer, primary_key=True, autoincrement=True)
     module_path = Column(String)
     operator_name = Column(String)
     operator_args = Column(JSON)
@@ -230,7 +232,7 @@ class MutationSpecStorage(Base):
     start_pos_col = Column(Integer)
     end_pos_row = Column(Integer)
     end_pos_col = Column(Integer)
-    job_id = Column(String, ForeignKey("work_items.job_id"), primary_key=True)
+    job_id = Column(String, ForeignKey("work_items.job_id"))
     work_item = relationship("WorkItemStorage", back_populates="mutations")
 
 

--- a/tests/e2e/test_higher_order_mutations.py
+++ b/tests/e2e/test_higher_order_mutations.py
@@ -1,0 +1,98 @@
+"""End-to-end tests for higher-order mutations."""
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+from cosmic_ray.work_db import WorkDB, use_db
+from cosmic_ray.work_item import WorkItem
+
+
+@pytest.fixture(scope="session")
+def higher_order_project_root():
+    """Path to the higher-order test project."""
+    # Use the absolute path to the project
+    return pathlib.Path("/home/andre/Repos/cosmic-ray/tests/resources/higher_order_test")
+    
+@pytest.fixture
+def session_file():
+    """Create a temporary session file for each test."""
+    with tempfile.NamedTemporaryFile(suffix='.sqlite', delete=False) as f:
+        session_path = f.name
+    
+    try:
+        yield pathlib.Path(session_path)
+    finally:
+        # Clean up after test
+        if os.path.exists(session_path):
+            os.unlink(session_path)
+
+
+def test_first_order_mutations(higher_order_project_root, session_file):
+    """Test that first-order mutations work correctly."""
+    config = "cosmic-ray.conf"  # This has mutation-order = 1
+    
+    # Initialize the session
+    subprocess.check_call(
+        [sys.executable, "-m", "cosmic_ray.cli", "init", config, str(session_file)],
+        cwd=str(higher_order_project_root),
+    )
+    
+    # Run the mutations
+    subprocess.check_call(
+        [sys.executable, "-m", "cosmic_ray.cli", "exec", config, str(session_file)],
+        cwd=str(higher_order_project_root),
+    )
+    
+    # Analyze the results
+    with use_db(str(session_file), WorkDB.Mode.open) as work_db:
+        # Count the number of work items
+        work_items = list(work_db.work_items)
+        
+        # Verify we only have first-order mutations (each with exactly one mutation)
+        assert all(len(item.mutations) == 1 for item in work_items)
+        
+        # Make sure we have some mutations (at least 10)
+        assert len(work_items) >= 10
+
+
+@pytest.mark.slow
+def test_second_order_mutations(higher_order_project_root, session_file):
+    """Test that second-order mutations work correctly."""
+    config = "cosmic-ray-order-2.conf"  # This has mutation-order = 2
+    
+    # Initialize the session
+    subprocess.check_call(
+        [sys.executable, "-m", "cosmic_ray.cli", "init", config, str(session_file)],
+        cwd=str(higher_order_project_root),
+    )
+    
+    # Run the mutations
+    subprocess.check_call(
+        [sys.executable, "-m", "cosmic_ray.cli", "exec", config, str(session_file)],
+        cwd=str(higher_order_project_root),
+    )
+    
+    # Analyze the results
+    with use_db(str(session_file), WorkDB.Mode.open) as work_db:
+        # Count the number of work items
+        work_items = list(work_db.work_items)
+        
+        # Count first-order and second-order mutations
+        first_order_count = sum(1 for item in work_items if len(item.mutations) == 1)
+        second_order_count = sum(1 for item in work_items if len(item.mutations) == 2)
+        
+        # We should have both first-order and second-order mutations
+        assert first_order_count > 0
+        assert second_order_count > 0
+        
+        # Total should be first + second order
+        assert len(work_items) == first_order_count + second_order_count
+        
+        # The combined total should be greater than just the first-order count
+        # This proves we're actually generating higher-order mutants
+        assert len(work_items) > first_order_count

--- a/tests/resources/higher_order_test/__init__.py
+++ b/tests/resources/higher_order_test/__init__.py
@@ -1,0 +1,1 @@
+"""Package for testing higher-order mutations."""

--- a/tests/resources/higher_order_test/adam.py
+++ b/tests/resources/higher_order_test/adam.py
@@ -1,0 +1,30 @@
+"""A simple module for testing higher-order mutations."""
+
+
+def add_and_compare(a, b, c):
+    """Add two numbers and compare with a third.
+    
+    This function contains multiple mutation opportunities:
+    1. Arithmetic operator replacement (+ to -, *, /, etc.)
+    2. Comparison operator replacement (> to <, ==, etc.)
+    """
+    result = a + b
+    if result > c:
+        return "Greater"
+    elif result < c:
+        return "Less"
+    else:
+        return "Equal"
+
+
+def check_logic(x, y):
+    """Test function with logic operations.
+    
+    This function contains multiple mutation opportunities in logical operators.
+    """
+    if x and y:
+        return "Both"
+    elif x or y:
+        return "At least one"
+    else:
+        return "None"

--- a/tests/resources/higher_order_test/cosmic-ray-order-2.conf
+++ b/tests/resources/higher_order_test/cosmic-ray-order-2.conf
@@ -1,0 +1,12 @@
+[cosmic-ray]
+module-path = "adam.py"
+timeout = 10
+excluded-modules = []
+test-command = "python -m pytest -x tests"
+mutation-order = 2
+distributor.name = "local"
+
+[cosmic-ray.operators]
+comparison_operator_replacement = true
+arithmetic_operator_replacement = true
+boolean_replacer = true

--- a/tests/resources/higher_order_test/cosmic-ray.conf
+++ b/tests/resources/higher_order_test/cosmic-ray.conf
@@ -1,0 +1,12 @@
+[cosmic-ray]
+module-path = "adam.py"
+timeout = 10
+excluded-modules = []
+test-command = "python -m pytest -x tests"
+mutation-order = 1
+distributor.name = "local"
+
+[cosmic-ray.operators]
+comparison_operator_replacement = true
+arithmetic_operator_replacement = true
+boolean_replacer = true

--- a/tests/resources/higher_order_test/tests/__init__.py
+++ b/tests/resources/higher_order_test/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for adam module."""

--- a/tests/resources/higher_order_test/tests/test_adam.py
+++ b/tests/resources/higher_order_test/tests/test_adam.py
@@ -1,0 +1,21 @@
+"""Tests for the adam module."""
+
+import unittest
+from adam import add_and_compare, check_logic
+
+
+class TestAdam(unittest.TestCase):
+    """Tests for functions in the adam module."""
+
+    def test_add_and_compare(self):
+        """Test the add_and_compare function."""
+        self.assertEqual(add_and_compare(2, 3, 4), "Greater")
+        self.assertEqual(add_and_compare(2, 3, 6), "Less")
+        self.assertEqual(add_and_compare(2, 3, 5), "Equal")
+
+    def test_check_logic(self):
+        """Test the check_logic function."""
+        self.assertEqual(check_logic(True, True), "Both")
+        self.assertEqual(check_logic(True, False), "At least one")
+        self.assertEqual(check_logic(False, True), "At least one")
+        self.assertEqual(check_logic(False, False), "None")

--- a/tests/unittests/test_higher_order_mutants.py
+++ b/tests/unittests/test_higher_order_mutants.py
@@ -1,0 +1,144 @@
+"""Tests for higher-order mutant functionality."""
+
+import pytest
+from pathlib import Path
+import itertools
+import uuid
+import sys
+from unittest import mock
+
+from cosmic_ray.work_item import MutationSpec, WorkItem, WorkResult, WorkerOutcome
+from cosmic_ray.work_item import TestOutcome as TOutcome
+from cosmic_ray.mutating import mutate_and_test
+from cosmic_ray.commands.init import _all_work_items
+import cosmic_ray.commands.init as init_module
+from cosmic_ray.work_db import WorkDB, use_db
+
+
+def test_workitem_with_multiple_mutations():
+    """Test that a WorkItem can be created with multiple mutations."""
+    mutations = [
+        MutationSpec(Path("path1"), "operator1", 0, (0, 0), (0, 1)),
+        MutationSpec(Path("path2"), "operator2", 1, (1, 0), (1, 1)),
+    ]
+    
+    # Create a WorkItem with multiple mutations
+    work_item = WorkItem(job_id="test_job", mutations=tuple(mutations))
+    
+    # Check that the WorkItem has the correct mutations
+    assert len(work_item.mutations) == 2
+    assert work_item.mutations[0].module_path == Path("path1")
+    assert work_item.mutations[0].operator_name == "operator1"
+    assert work_item.mutations[1].module_path == Path("path2")
+    assert work_item.mutations[1].operator_name == "operator2"
+
+
+def test_init_creates_higher_order_mutants(monkeypatch):
+    """Test that the init command creates higher-order mutants when configured."""
+    # Mock the _generate_mutations function to return a fixed set of mutations
+    mock_mutations = [
+        MutationSpec(Path("path1"), "operator1", 0, (0, 0), (0, 1)),
+        MutationSpec(Path("path2"), "operator2", 1, (1, 0), (1, 1)),
+        MutationSpec(Path("path3"), "operator3", 2, (2, 0), (2, 1)),
+    ]
+    
+    # Mock uuid.uuid4().hex to return predictable values
+    monkeypatch.setattr(uuid, "uuid4", lambda: type('obj', (object,), {'hex': 'test-uuid'}))
+    
+    # Use mock.patch to patch the module function
+    with mock.patch('cosmic_ray.commands.init._generate_mutations', return_value=mock_mutations):
+        # Get all work items with mutation_order=1 (first-order only)
+        work_items_first_order = list(_all_work_items([], {}, mutation_order=1))
+        
+        # There should be 3 work items (one for each mutation)
+        assert len(work_items_first_order) == 3
+        
+        # Each work item should have exactly one mutation
+        for item in work_items_first_order:
+            assert len(item.mutations) == 1
+        
+        # Get all work items with mutation_order=2 (first and second-order)
+        work_items_second_order = list(_all_work_items([], {}, mutation_order=2))
+        
+        # There should be 3 first-order + 3 choose 2 second-order = 3 + 3 = 6 work items
+        assert len(work_items_second_order) == 6
+        
+        # Count the number of each order
+        first_order_count = sum(1 for item in work_items_second_order if len(item.mutations) == 1)
+        second_order_count = sum(1 for item in work_items_second_order if len(item.mutations) == 2)
+        
+        assert first_order_count == 3
+        assert second_order_count == 3
+        
+        # Get all work items with mutation_order=3 (first, second, and third-order)
+        work_items_third_order = list(_all_work_items([], {}, mutation_order=3))
+        
+        # There should be 3 first-order + 3 choose 2 second-order + 3 choose 3 third-order = 3 + 3 + 1 = 7 work items
+        assert len(work_items_third_order) == 7
+        
+        # Count the number of each order
+        first_order_count = sum(1 for item in work_items_third_order if len(item.mutations) == 1)
+        second_order_count = sum(1 for item in work_items_third_order if len(item.mutations) == 2)
+        third_order_count = sum(1 for item in work_items_third_order if len(item.mutations) == 3)
+        
+        assert first_order_count == 3
+        assert second_order_count == 3
+        assert third_order_count == 1
+
+
+def test_multiple_mutations_generated_correctly(monkeypatch):
+    """Test that all combinations of mutations are generated correctly."""
+    # Create 5 mock mutations
+    mock_mutations = [
+        MutationSpec(Path(f"path{i}"), f"operator{i}", i, (i, 0), (i, 1))
+        for i in range(5)
+    ]
+    
+    # Mock uuid.uuid4().hex to return predictable values
+    monkeypatch.setattr(uuid, "uuid4", lambda: type('obj', (object,), {'hex': 'test-uuid'}))
+    
+    # Use mock.patch to patch the module function
+    with mock.patch('cosmic_ray.commands.init._generate_mutations', return_value=mock_mutations):
+        # Test with mutation_order=3
+        work_items = list(_all_work_items([], {}, mutation_order=3))
+        
+        # Calculate expected combinations manually
+        expected_combinations = sum(len(list(itertools.combinations(mock_mutations, i))) for i in range(1, 4))
+        
+        # There should be one work item for each combination
+        assert len(work_items) == expected_combinations
+        
+        # Verify that each work item has the correct number of mutations
+        order_counts = {1: 0, 2: 0, 3: 0}
+        for item in work_items:
+            mutation_count = len(item.mutations)
+            assert 1 <= mutation_count <= 3
+            order_counts[mutation_count] += 1
+        
+        # Verify the counts match what we expect
+        assert order_counts[1] == 5  # 5 choose 1 = 5
+        assert order_counts[2] == 10  # 5 choose 2 = 10
+        assert order_counts[3] == 10  # 5 choose 3 = 10
+
+
+def test_multiple_mutation_unique_ids():
+    """Test that each work item gets a unique ID even with multiple mutations."""
+    # Test directly with WorkItem objects
+    mutation1 = MutationSpec(Path("path1"), "operator1", 0, (0, 0), (0, 1))
+    mutation2 = MutationSpec(Path("path2"), "operator2", 1, (1, 0), (1, 1))
+    
+    # Add single mutation work item
+    item1 = WorkItem.single(job_id="job1", mutation=mutation1)
+    
+    # Add multiple mutation work item
+    item2 = WorkItem(job_id="job2", mutations=(mutation1, mutation2))
+    
+    # Verify both work items have the correct structure
+    assert item1.job_id == "job1"
+    assert len(item1.mutations) == 1
+    assert item1.mutations[0].module_path == Path("path1")
+    
+    assert item2.job_id == "job2"
+    assert len(item2.mutations) == 2
+    assert item2.mutations[0].module_path == Path("path1")
+    assert item2.mutations[1].module_path == Path("path2")

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version < '3.13'",
@@ -310,7 +311,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -340,7 +341,6 @@ wheels = [
 
 [[package]]
 name = "cosmic-ray"
-version = "8.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
This implementation adds support for higher-order mutants (multiple mutations applied simultaneously). Key changes include:

1. Added mutation-order config option to control mutation order
2. Refactored database schema to support multiple mutations per work item
3. Updated CLI to support testing multiple mutations at once
4. Added comprehensive tests for higher-order mutations
5. Added detailed documentation and examples

Closes #296