### PR TITLE
Issue #565 - Avoid mutating pipe operator in assignment annotations

### DIFF
--- a/src/cosmic_ray/operators/binary_operator_replacement.py
+++ b/src/cosmic_ray/operators/binary_operator_replacement.py
@@ -65,7 +65,13 @@ def _is_binary_operator(node):
         if isinstance(node.parent, parso.python.tree.Param):
             return False
 
-        if node.parent.type in _NON_BINARY_PARENTS:
+        operator_is_pipe_in_assignment_annotation = (
+            (node.value == "|")
+            and (node.parent and node.parent.type == "expr")
+            and (node.parent.parent and node.parent.parent.type == "annassign")
+        )
+
+        if node.parent.type in _NON_BINARY_PARENTS or operator_is_pipe_in_assignment_annotation:
             return False
 
         return True

--- a/tests/unittests/operators/test_binary_operator_replacement.py
+++ b/tests/unittests/operators/test_binary_operator_replacement.py
@@ -1,9 +1,40 @@
 from cosmic_ray.mutating import mutate_code
 from cosmic_ray.operators.binary_operator_replacement import (
     ReplaceBinaryOperator_Add_Mul,
+    ReplaceBinaryOperator_BitOr_Add,
     ReplaceBinaryOperator_Mul_Add,
     ReplaceBinaryOperator_Sub_Add,
 )
+
+
+def test_pipe_operator_in_assignment_annotation_not_mutated_as_binary_operator():
+    code = "my_var: str | int = 10"
+    mutated = mutate_code(code, ReplaceBinaryOperator_BitOr_Add(), 0)
+    assert mutated is None
+
+
+def test_pipe_operator_in_local_assignment_annotation_not_mutated_as_binary_operator():
+    code = r"""
+def my_function():
+    local_var: str | int = 3
+"""
+    mutated = mutate_code(code, ReplaceBinaryOperator_BitOr_Add(), 0)
+    assert mutated is None
+
+
+def test_pipe_in_function_argument_type_annotation_mutated_as_binary_operator():
+    code = r"""
+def my_function(arg: str | int = 10):
+    local_var = arg
+"""
+    mutated = mutate_code(code, ReplaceBinaryOperator_BitOr_Add(), 0)
+    assert mutated is not None
+
+
+def test_bitwise_or_mutated_as_binary_operator():
+    code = "my_var = 10 | 2"
+    mutated = mutate_code(code, ReplaceBinaryOperator_BitOr_Add(), 0)
+    assert mutated is not None
 
 
 def test_import_star_not_mutated_as_binary_operator():


### PR DESCRIPTION
Currently, mutating pipes in the annotations of assignments create false mutant survivals because there is not runtime implications (errors or otherwise).

This patch will prevent the pipe character within the annotations of assignments from being seen as a binary operator, thus preventing mutations of that character and eliminating the false-positive mutant survival.