### PR TITLE
Add function_name field to mutation reports

### DIFF
--- a/src/cosmic_ray/ast/ast_query.py
+++ b/src/cosmic_ray/ast/ast_query.py
@@ -1,5 +1,7 @@
 "Tools for querying ASTs."
 
+import parso.python.tree
+
 
 class ASTQuery:
     """
@@ -92,6 +94,15 @@ class ASTQuery:
         if self.obj is None:
             return self
         return self._clone(self.obj[item])
+
+    def get_definition_name(self):
+        "Get the name of the function or class enclosing the current node."
+        obj = self.obj
+        while obj:
+            if isinstance(obj, (parso.python.tree.Function, parso.python.tree.Class)):
+                return obj.name.value
+            obj = obj.parent
+        return None
 
 
 class ASTQueryOptional(ASTQuery):

--- a/src/cosmic_ray/cli.py
+++ b/src/cosmic_ray/cli.py
@@ -15,6 +15,8 @@ from collections import defaultdict
 from contextlib import contextmanager, redirect_stdout
 from pathlib import Path
 
+from attrs import asdict
+
 import click
 from exit_codes import ExitCode
 from rich.logging import RichHandler
@@ -182,13 +184,13 @@ def dump(session_file):
     """
 
     def item_to_dict(work_item):
-        d = dataclasses.asdict(work_item)
+        d = asdict(work_item)
         for m in d["mutations"]:
             m["module_path"] = str(m["module_path"])
         return d
 
     def result_to_dict(result):
-        d = dataclasses.asdict(result)
+        d = asdict(result)
         d["worker_outcome"] = d["worker_outcome"].value
         d["test_outcome"] = d["test_outcome"].value
         return d

--- a/src/cosmic_ray/tools/html.py
+++ b/src/cosmic_ray/tools/html.py
@@ -241,7 +241,10 @@ def _generate_work_item_card(doc, index, work_item, result, skip_success):
                                     )
 
                         with tag("pre"):
-                            text(f"operator: {mutation.operator_name}, occurrence: {mutation.occurrence}")
+                            text(
+                                f"operator: {mutation.operator_name}, occurrence: {mutation.occurrence},"
+                                f" function_name: {mutation.function_name}"
+                            )
 
                     if result is not None:
                         if result.diff:

--- a/src/cosmic_ray/work_db.py
+++ b/src/cosmic_ray/work_db.py
@@ -230,6 +230,7 @@ class MutationSpecStorage(Base):
     start_pos_col = Column(Integer)
     end_pos_row = Column(Integer)
     end_pos_col = Column(Integer)
+    function_name = Column(String, nullable=True)
     job_id = Column(String, ForeignKey("work_items.job_id"), primary_key=True)
     work_item = relationship("WorkItemStorage", back_populates="mutations")
 
@@ -254,6 +255,7 @@ def _mutation_spec_from_storage(mutation_spec: MutationSpecStorage):
         occurrence=mutation_spec.occurrence,
         start_pos=(mutation_spec.start_pos_row, mutation_spec.start_pos_col),
         end_pos=(mutation_spec.end_pos_row, mutation_spec.end_pos_col),
+        function_name=mutation_spec.function_name,
     )
 
 
@@ -268,6 +270,7 @@ def _mutation_spec_to_storage(mutation_spec: MutationSpec, job_id: str):
         start_pos_col=mutation_spec.start_pos[1],
         end_pos_row=mutation_spec.end_pos[0],
         end_pos_col=mutation_spec.end_pos[1],
+        function_name=mutation_spec.function_name,
     )
 
 

--- a/src/cosmic_ray/work_item.py
+++ b/src/cosmic_ray/work_item.py
@@ -63,6 +63,7 @@ class MutationSpec:
     start_pos: tuple[int, int] = field()
     end_pos: tuple[int, int] = field()
     operator_args: dict[str, Any] = field(factory=dict)
+    function_name: Optional[str] = field(default=None)
 
     @end_pos.validator
     def _validate_positions(self, attribute, value):


### PR DESCRIPTION
This pull request adds a 'function_name' field to mutation reports in Cosmic Ray. 

Purpose:
- Allows users to see in which function a mutation occurred.
- Helps prioritize testing for important or critical functions.
- Enables filtering out less important or trivial functions from mutation testing.

Note:
- This implementation does not include unit tests yet.
- The feature is intended to enhance reporting and filtering, without changing existing mutation behavior.
