### PR TITLE
Issue #581 - Skip lambda nodes in get_definition_name

### DIFF
--- a/src/cosmic_ray/ast/ast_query.py
+++ b/src/cosmic_ray/ast/ast_query.py
@@ -99,6 +99,9 @@ class ASTQuery:
         "Get the name of the function or class enclosing the current node."
         obj = self.obj
         while obj:
+            if isinstance(obj, parso.python.tree.Lambda):
+                obj = obj.parent
+                continue
             if isinstance(obj, (parso.python.tree.Function, parso.python.tree.Class)):
                 return obj.name.value
             obj = obj.parent

--- a/tests/unittests/test_ast.py
+++ b/tests/unittests/test_ast.py
@@ -1,4 +1,5 @@
-from cosmic_ray.ast import get_ast_from_path
+from cosmic_ray.ast import ast_nodes, get_ast_from_path
+from cosmic_ray.ast.ast_query import ASTQuery
 
 
 def test_call_get_ast_from_path(tmp_path):
@@ -7,6 +8,34 @@ def test_call_get_ast_from_path(tmp_path):
     module_filepath.write_text(input_code)
     ast = get_ast_from_path(module_filepath)
     assert ast.get_code() == input_code
+
+
+def _definition_names_from_source(tmp_path, source):
+    """Parse source and return definition names for all AST nodes."""
+    module_path = tmp_path / "module.py"
+    module_path.write_text(source)
+    module_ast = get_ast_from_path(module_path)
+    return [ASTQuery(node).get_definition_name() for node in ast_nodes(module_ast)]
+
+
+def test_get_definition_name_lambda_inside_function(tmp_path):
+    source = "def foo():\n    xs = sorted(xs, key=lambda x: x)\n"
+    names = _definition_names_from_source(tmp_path, source)
+    assert "foo" in names
+    assert all(n in ("foo", None) for n in names)
+
+
+def test_get_definition_name_lambda_at_module_level(tmp_path):
+    source = "f = lambda x: x + 1\n"
+    names = _definition_names_from_source(tmp_path, source)
+    assert all(n is None for n in names)
+
+
+def test_get_definition_name_lambda_inside_class(tmp_path):
+    source = "class Bar:\n    fn = lambda self: self\n"
+    names = _definition_names_from_source(tmp_path, source)
+    assert "Bar" in names
+    assert all(n in ("Bar", None) for n in names)
 
 
 def test_call_get_ast_from_path_with_non_utf8_encoding(tmp_path):


### PR DESCRIPTION
This PR fixes #581.

`get_definition_name()` crashes with `AttributeError: lambda is not named` 
when the target module contains lambda expressions.

**Root cause**: `parso.python.tree.Lambda` is a subclass of `Function`, so
`isinstance(obj, Function)` at `ast_query.py:102` matches it. But
`Lambda.name` raises `AttributeError` because lambdas are anonymous.

**Fix**: Skip `Lambda` nodes and continue walking up to the enclosing
named `Function` or `Class`. Module-level lambdas correctly return `None`.

Lambdas currently crash the entire `init` phase, so any handling is an
improvement. The only caller is `commands/init.py:65`, which uses the
result as a label for the mutant — the enclosing function/class name
(or `None` for module-level) is the correct label.

## Minimal reproducer

```python
# module_with_lambda.py
def foo():
    xs = sorted(xs, key=lambda x: x)
```

```bash
cosmic-ray init config.toml session.sqlite
# => AttributeError: lambda is not named.
```

## Tests added

- test_get_definition_name_lambda_inside_function — returns enclosing function name
- test_get_definition_name_lambda_at_module_level — returns None
- test_get_definition_name_lambda_inside_class — returns enclosing class name

All 641 existing tests continue to pass (2 skipped, 6 xfailed).