### PR TITLE
Add configurable line-based mutation filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ cr-xml = "cosmic_ray.tools.xml:report_xml"
 cr-filter-operators = "cosmic_ray.tools.filters.operators_filter:main"
 cr-filter-pragma = "cosmic_ray.tools.filters.pragma_no_mutate:main"
 cr-filter-git = "cosmic_ray.tools.filters.git:main"
+cr-filter-lines = "cosmic_ray.tools.filters.line_filter:main"
 cr-http-workers = "cosmic_ray.tools.http_workers:main"
 
 [project.entry-points."cosmic_ray.operator_providers"]

--- a/src/cosmic_ray/tools/filters/line_filter.py
+++ b/src/cosmic_ray/tools/filters/line_filter.py
@@ -21,12 +21,10 @@ class LineFilter(FilterApp):
         return __doc__
 
     def add_args(self, parser):
-        parser.add_argument("--config", help="Config file to use")
+        parser.add_argument("--config", required=True, help="Config file to use")
 
     def filter(self, work_db: WorkDB, args: Namespace):
-        config = ConfigDict()
-        if args.config is not None:
-            config = load_config(args.config)
+        config = load_config(args.config)
 
         module_path = config.get("module-path", "")
 

--- a/src/cosmic_ray/tools/filters/line_filter.py
+++ b/src/cosmic_ray/tools/filters/line_filter.py
@@ -110,10 +110,10 @@ class LineFilter(FilterApp):
 
         for file_key, specs in files.items():
             file_path = self._resolve_module_path(file_key, module_path_cfg)
-            
+
             if file_path is None:
                 continue
-            
+
             parsed[file_path] = self._parse_line_specs(specs)
 
         return parsed

--- a/src/cosmic_ray/tools/filters/line_filter.py
+++ b/src/cosmic_ray/tools/filters/line_filter.py
@@ -81,10 +81,28 @@ class LineFilter(FilterApp):
         return normalized_lines_cfg
 
     def _resolve_module_path(self, file_key, module_path_cfg):
-        base = Path(module_path_cfg) if module_path_cfg else None
         file_path = Path(file_key)
 
-        if not file_path.is_absolute() and base is not None:
+        if not module_path_cfg:
+            return file_path
+
+        base = Path(module_path_cfg)
+
+        if base.suffix:
+            if file_path.is_absolute():
+                return file_path
+
+            if file_path == base or file_path == Path(base.name):
+                return base
+
+            log.warning(
+                "line-filter: config file key %r does not match single-file module-path %r; ignoring this entry",
+                file_key,
+                module_path_cfg,
+            )
+            return None
+
+        if not file_path.is_absolute():
             file_path = base / file_path
 
         return file_path
@@ -94,6 +112,10 @@ class LineFilter(FilterApp):
 
         for file_key, specs in files.items():
             file_path = self._resolve_module_path(file_key, module_path_cfg)
+            
+            if file_path is None:
+                continue
+            
             parsed[file_path] = self._parse_line_specs(specs)
 
         return parsed

--- a/src/cosmic_ray/tools/filters/line_filter.py
+++ b/src/cosmic_ray/tools/filters/line_filter.py
@@ -57,11 +57,8 @@ class LineFilter(FilterApp):
         if lines_cfg is None:
             lines_cfg = {}
         if not isinstance(lines_cfg, Mapping):
-            raise ValueError(
-                "line-filter 'lines' section must be a mapping "
-                "from module path to line specification(s)."
-            )
-            
+            raise ValueError("line-filter 'lines' section must be a mapping from module path to line specification(s).")
+
         normalized_lines_cfg = {}
         for file_key, specs in lines_cfg.items():
             if isinstance(specs, str):
@@ -82,7 +79,6 @@ class LineFilter(FilterApp):
 
             normalized_lines_cfg[file_key] = specs_list
         return normalized_lines_cfg
-
 
     def _resolve_module_path(self, file_key, module_path_cfg):
         base = Path(module_path_cfg) if module_path_cfg else None
@@ -139,9 +135,7 @@ class LineFilter(FilterApp):
             for mutation in item.mutations:
                 ranges = parsed_files.get(mutation.module_path)
 
-                if not ranges or not self._ranges_overlap(
-                    mutation.start_pos[0], mutation.end_pos[0], ranges
-                ):
+                if not ranges or not self._ranges_overlap(mutation.start_pos[0], mutation.end_pos[0], ranges):
                     log.info(
                         "line-filter skipping %s %s %s %s %s %s",
                         item.job_id,
@@ -162,7 +156,6 @@ class LineFilter(FilterApp):
                     worker_outcome=WorkerOutcome.SKIPPED,
                 ),
             )
-
 
     def _ranges_overlap(self, m_start, m_end, ranges):
         return any(m_start <= r_end and r_start <= m_end for r_start, r_end in ranges)

--- a/src/cosmic_ray/tools/filters/line_filter.py
+++ b/src/cosmic_ray/tools/filters/line_filter.py
@@ -3,7 +3,6 @@
 import logging
 import sys
 from argparse import Namespace
-
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -71,17 +70,14 @@ class LineFilter(FilterApp):
                 specs_list = list(specs)
             else:
                 raise ValueError(
-                    "line-filter 'lines' values must be a string or a list/tuple "
-                    "of strings; got %r for %r" % (type(specs).__name__, file_key)
+                    f"line-filter 'lines' values must be a string or a list/tuple "
+                    f"of strings; got {type(specs).__name__!r} for {file_key!r}"
                 )
 
             for spec in specs_list:
                 if not isinstance(spec, str):
                     raise ValueError(
-                        "line-filter 'lines' entries must be strings; got %r in %r" % (
-                            type(spec).__name__,
-                            file_key,
-                        )
+                        f"line-filter 'lines' entries must be strings; got {type(spec).__name__!r} in {file_key!r}"
                     )
 
             normalized_lines_cfg[file_key] = specs_list

--- a/src/cosmic_ray/tools/filters/line_filter.py
+++ b/src/cosmic_ray/tools/filters/line_filter.py
@@ -1,0 +1,181 @@
+"""A filter that skips mutations outside configured line ranges."""
+
+import logging
+import sys
+from argparse import Namespace
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from cosmic_ray.config import ConfigDict, load_config
+from cosmic_ray.tools.filters.filter_app import FilterApp
+from cosmic_ray.work_db import WorkDB
+from cosmic_ray.work_item import WorkResult, WorkerOutcome
+
+log = logging.getLogger()
+
+
+class LineFilter(FilterApp):
+    """Implements the line filter."""
+
+    def description(self):
+        return __doc__
+
+    def add_args(self, parser):
+        parser.add_argument("--config", help="Config file to use")
+
+    def filter(self, work_db: WorkDB, args: Namespace):
+        config = ConfigDict()
+        if args.config is not None:
+            config = load_config(args.config)
+
+        module_path = config.get("module-path", "")
+
+        if isinstance(module_path, list):
+            if len(module_path) != 1:
+                raise ValueError(
+                    "line-filter does not support multiple 'module-path' entries; "
+                    "configure a single module-path when using this filter."
+                )
+            module_path = module_path[0]
+
+        lf_config = config.sub("filters", "line-filter")
+        raw_lines_cfg = lf_config.get("lines")
+
+        normalized_lines_cfg = self._normalize_lines_config(raw_lines_cfg)
+        line_ranges = self._parse_line_files(normalized_lines_cfg, module_path)
+
+        if not line_ranges:
+            log.warning(
+                "line-filter: no line ranges configured; all mutations will be skipped",
+            )
+
+        log.info("Line filter included ranges: %s", line_ranges)
+
+        self._skip_filtered(work_db, line_ranges)
+
+    def _normalize_lines_config(self, lines_cfg):
+        if lines_cfg is None:
+            lines_cfg = {}
+        if not isinstance(lines_cfg, Mapping):
+            raise ValueError(
+                "line-filter 'lines' section must be a mapping "
+                "from module path to line specification(s)."
+            )
+            
+        normalized_lines_cfg = {}
+        for file_key, specs in lines_cfg.items():
+            if isinstance(specs, str):
+                specs_list = [specs]
+            elif isinstance(specs, (list, tuple)):
+                specs_list = list(specs)
+            else:
+                raise ValueError(
+                    "line-filter 'lines' values must be a string or a list/tuple "
+                    "of strings; got %r for %r" % (type(specs).__name__, file_key)
+                )
+
+            for spec in specs_list:
+                if not isinstance(spec, str):
+                    raise ValueError(
+                        "line-filter 'lines' entries must be strings; got %r in %r" % (
+                            type(spec).__name__,
+                            file_key,
+                        )
+                    )
+
+            normalized_lines_cfg[file_key] = specs_list
+        return normalized_lines_cfg
+
+
+    def _resolve_module_path(self, file_key, module_path_cfg):
+        base = Path(module_path_cfg) if module_path_cfg else None
+        file_path = Path(file_key)
+
+        if not file_path.is_absolute() and base is not None:
+            file_path = base / file_path
+
+        return file_path
+
+    def _parse_line_files(self, files, module_path_cfg):
+        parsed = {}
+
+        for file_key, specs in files.items():
+            file_path = self._resolve_module_path(file_key, module_path_cfg)
+            parsed[file_path] = self._parse_line_specs(specs)
+
+        return parsed
+
+    def _parse_line_specs(self, specs):
+        ranges = []
+
+        for spec in specs:
+            spec = spec.strip()
+            if not spec:
+                continue
+
+            try:
+                if "-" in spec:
+                    start, end = map(int, spec.split("-", 1))
+                else:
+                    start = end = int(spec)
+            except ValueError:
+                log.warning("line-filter: invalid line specification '%s' – skipping", spec)
+                continue
+
+            if start < 1 or end < start:
+                log.warning(
+                    "line-filter: nonsensical line range '%s' (interpreted as %s-%s) – skipping",
+                    spec,
+                    start,
+                    end,
+                )
+                continue
+
+            ranges.append((start, end))
+
+        return ranges
+
+    def _skip_filtered(self, work_db, parsed_files):
+        job_ids = []
+
+        for item in work_db.pending_work_items:
+            for mutation in item.mutations:
+                ranges = parsed_files.get(mutation.module_path)
+
+                if not ranges or not self._ranges_overlap(
+                    mutation.start_pos[0], mutation.end_pos[0], ranges
+                ):
+                    log.info(
+                        "line-filter skipping %s %s %s %s %s %s",
+                        item.job_id,
+                        mutation.operator_name,
+                        mutation.occurrence,
+                        mutation.module_path,
+                        mutation.start_pos,
+                        mutation.end_pos,
+                    )
+
+                    job_ids.append(item.job_id)
+
+        if job_ids:
+            work_db.set_multiple_results(
+                job_ids,
+                WorkResult(
+                    output="Filtered line-filter",
+                    worker_outcome=WorkerOutcome.SKIPPED,
+                ),
+            )
+
+
+    def _ranges_overlap(self, m_start, m_end, ranges):
+        return any(m_start <= r_end and r_start <= m_end for r_start, r_end in ranges)
+
+
+def main(argv=None):
+    """Run the line-filter with the specified command line arguments."""
+    return LineFilter().main(argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tools/test_filter_lines.py
+++ b/tests/tools/test_filter_lines.py
@@ -8,10 +8,7 @@ import pytest
 # workspace isn't available in the test environment.
 skip_in_ci = pytest.mark.xfail(
     os.environ.get("GITHUB_ACTIONS") == "true",
-    reason=(
-        "This test fails on non-master branches in CI, so we ignore this "
-        "problem for now."
-    ),
+    reason=("This test fails on non-master branches in CI, so we ignore this problem for now."),
 )
 
 
@@ -37,4 +34,3 @@ def test_smoke_test_on_execd_session(execd_session, fast_tests_root):
     ]
 
     subprocess.check_call(command, cwd=str(fast_tests_root))
-

--- a/tests/tools/test_filter_lines.py
+++ b/tests/tools/test_filter_lines.py
@@ -106,7 +106,7 @@ class FakeWorkDB:
     def set_multiple_results(self, job_ids, work_result: WorkResult):
         for job_id in job_ids:
             self.results.append((job_id, work_result.worker_outcome))
-            
+
 
 def test_line_filter_skips_items_outside_configured_ranges():
     data = FakeWorkDB()
@@ -122,8 +122,8 @@ def test_line_filter_skips_items_outside_configured_ranges():
         ("id4", WorkerOutcome.SKIPPED),
         ("id5", WorkerOutcome.SKIPPED),
     ]
-    
-    
+
+
 def test_line_filter_skips_all_items_when_no_files_are_configured():
     data = FakeWorkDB()
     parsed_files = {}
@@ -151,6 +151,7 @@ def test_line_filter_keeps_all_items_when_all_ranges_match():
 
     assert data.results == []
 
+
 def test_line_filter_supports_multiple_ranges_for_same_file():
     data = FakeWorkDB()
     parsed_files = {
@@ -163,6 +164,7 @@ def test_line_filter_supports_multiple_ranges_for_same_file():
     assert data.results == [
         ("id5", WorkerOutcome.SKIPPED),
     ]
+
 
 def test_line_filter_supports_multiple_files():
     data = FakeWorkDB()
@@ -178,6 +180,7 @@ def test_line_filter_supports_multiple_files():
         ("id4", WorkerOutcome.SKIPPED),
         ("id5", WorkerOutcome.SKIPPED),
     ]
+
 
 def test_ranges_overlap_returns_true_when_mutation_overlaps_range():
     result = line_filter.LineFilter()._ranges_overlap(3, 5, [(1, 4)])

--- a/tests/tools/test_filter_lines.py
+++ b/tests/tools/test_filter_lines.py
@@ -4,7 +4,6 @@ import sys
 
 import pytest
 
-
 # Skip these tests when running in GitHub Actions where a proper git
 # workspace isn't available in the test environment.
 skip_in_ci = pytest.mark.xfail(

--- a/tests/tools/test_filter_lines.py
+++ b/tests/tools/test_filter_lines.py
@@ -1,8 +1,12 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
+
+from cosmic_ray.tools.filters import line_filter
+from cosmic_ray.work_item import MutationSpec, WorkItem, WorkResult, WorkerOutcome
 
 # Skip these tests when running in GitHub Actions where a proper git
 # workspace isn't available in the test environment.
@@ -19,6 +23,8 @@ def test_smoke_test_on_initialized_session(initialized_session, fast_tests_root)
         "-m",
         "cosmic_ray.tools.filters.line_filter",
         str(initialized_session.session),
+        "--config",
+        str(initialized_session.config),
     ]
 
     subprocess.check_call(command, cwd=str(fast_tests_root))
@@ -31,6 +37,203 @@ def test_smoke_test_on_execd_session(execd_session, fast_tests_root):
         "-m",
         "cosmic_ray.tools.filters.line_filter",
         str(execd_session.session),
+        "--config",
+        str(execd_session.config),
     ]
 
     subprocess.check_call(command, cwd=str(fast_tests_root))
+
+
+class FakeWorkDB:
+    def __init__(self):
+        self.results = []
+
+    @property
+    def pending_work_items(self):
+        return [
+            WorkItem.single(
+                "id1",
+                MutationSpec(
+                    module_path=Path("math.py"),
+                    operator_name="Op1",
+                    occurrence=1,
+                    start_pos=(2, 0),
+                    end_pos=(2, 5),
+                ),
+            ),
+            WorkItem.single(
+                "id2",
+                MutationSpec(
+                    module_path=Path("math.py"),
+                    operator_name="Op2",
+                    occurrence=2,
+                    start_pos=(10, 0),
+                    end_pos=(10, 5),
+                ),
+            ),
+            WorkItem.single(
+                "id3",
+                MutationSpec(
+                    module_path=Path("util.py"),
+                    operator_name="Op3",
+                    occurrence=3,
+                    start_pos=(3, 0),
+                    end_pos=(3, 5),
+                ),
+            ),
+            WorkItem.single(
+                "id4",
+                MutationSpec(
+                    module_path=Path("util.py"),
+                    operator_name="Op4",
+                    occurrence=4,
+                    start_pos=(12, 0),
+                    end_pos=(12, 5),
+                ),
+            ),
+            WorkItem.single(
+                "id5",
+                MutationSpec(
+                    module_path=Path("other.py"),
+                    operator_name="Op5",
+                    occurrence=5,
+                    start_pos=(1, 0),
+                    end_pos=(1, 5),
+                ),
+            ),
+        ]
+
+    def set_multiple_results(self, job_ids, work_result: WorkResult):
+        for job_id in job_ids:
+            self.results.append((job_id, work_result.worker_outcome))
+            
+
+def test_line_filter_skips_items_outside_configured_ranges():
+    data = FakeWorkDB()
+    parsed_files = {
+        Path("math.py"): [(1, 4)],
+    }
+
+    line_filter.LineFilter()._skip_filtered(data, parsed_files)
+
+    assert data.results == [
+        ("id2", WorkerOutcome.SKIPPED),
+        ("id3", WorkerOutcome.SKIPPED),
+        ("id4", WorkerOutcome.SKIPPED),
+        ("id5", WorkerOutcome.SKIPPED),
+    ]
+    
+    
+def test_line_filter_skips_all_items_when_no_files_are_configured():
+    data = FakeWorkDB()
+    parsed_files = {}
+
+    line_filter.LineFilter()._skip_filtered(data, parsed_files)
+
+    assert data.results == [
+        ("id1", WorkerOutcome.SKIPPED),
+        ("id2", WorkerOutcome.SKIPPED),
+        ("id3", WorkerOutcome.SKIPPED),
+        ("id4", WorkerOutcome.SKIPPED),
+        ("id5", WorkerOutcome.SKIPPED),
+    ]
+
+
+def test_line_filter_keeps_all_items_when_all_ranges_match():
+    data = FakeWorkDB()
+    parsed_files = {
+        Path("math.py"): [(1, 20)],
+        Path("util.py"): [(1, 20)],
+        Path("other.py"): [(1, 5)],
+    }
+
+    line_filter.LineFilter()._skip_filtered(data, parsed_files)
+
+    assert data.results == []
+
+def test_line_filter_supports_multiple_ranges_for_same_file():
+    data = FakeWorkDB()
+    parsed_files = {
+        Path("math.py"): [(1, 4), (10, 10)],
+        Path("util.py"): [(3, 3), (12, 12)],
+    }
+
+    line_filter.LineFilter()._skip_filtered(data, parsed_files)
+
+    assert data.results == [
+        ("id5", WorkerOutcome.SKIPPED),
+    ]
+
+def test_line_filter_supports_multiple_files():
+    data = FakeWorkDB()
+    parsed_files = {
+        Path("math.py"): [(1, 4)],
+        Path("util.py"): [(1, 5)],
+    }
+
+    line_filter.LineFilter()._skip_filtered(data, parsed_files)
+
+    assert data.results == [
+        ("id2", WorkerOutcome.SKIPPED),
+        ("id4", WorkerOutcome.SKIPPED),
+        ("id5", WorkerOutcome.SKIPPED),
+    ]
+
+def test_ranges_overlap_returns_true_when_mutation_overlaps_range():
+    result = line_filter.LineFilter()._ranges_overlap(3, 5, [(1, 4)])
+
+    assert result is True
+
+
+def test_ranges_overlap_returns_false_when_mutation_does_not_overlap_range():
+    result = line_filter.LineFilter()._ranges_overlap(10, 12, [(1, 4)])
+
+    assert result is False
+
+
+def test_parse_line_specs_supports_single_lines_and_ranges():
+    result = line_filter.LineFilter()._parse_line_specs(["2", "5-7"])
+
+    assert result == [(2, 2), (5, 7)]
+
+
+def test_parse_line_specs_ignores_invalid_entries():
+    result = line_filter.LineFilter()._parse_line_specs(["2", "bad", "7-3", "5-6"])
+
+    assert result == [(2, 2), (5, 6)]
+
+
+def test_parse_line_files_resolves_paths_relative_to_module_path_directory():
+    files = {
+        "math.py": ["1-4"],
+        "util.py": ["10"],
+    }
+
+    result = line_filter.LineFilter()._parse_line_files(files, "src")
+
+    assert result == {
+        Path("src") / "math.py": [(1, 4)],
+        Path("src") / "util.py": [(10, 10)],
+    }
+
+
+def test_parse_line_files_supports_single_file_module_path_with_basename():
+    files = {
+        "my_math.py": ["2-4"],
+    }
+
+    result = line_filter.LineFilter()._parse_line_files(files, "src/my_math.py")
+
+    assert result == {
+        Path("src/my_math.py"): [(2, 4)],
+    }
+
+
+def test_parse_line_files_ignores_mismatched_file_for_single_file_module_path():
+    files = {
+        "other.py": ["1-3"],
+    }
+
+    result = line_filter.LineFilter()._parse_line_files(files, "src/my_math.py")
+
+    assert result == {}

--- a/tests/tools/test_filter_lines.py
+++ b/tests/tools/test_filter_lines.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+# Skip these tests when running in GitHub Actions where a proper git
+# workspace isn't available in the test environment.
+skip_in_ci = pytest.mark.xfail(
+    os.environ.get("GITHUB_ACTIONS") == "true",
+    reason=(
+        "This test fails on non-master branches in CI, so we ignore this "
+        "problem for now."
+    ),
+)
+
+
+@skip_in_ci
+def test_smoke_test_on_initialized_session(initialized_session, fast_tests_root):
+    command = [
+        sys.executable,
+        "-m",
+        "cosmic_ray.tools.filters.line_filter",
+        str(initialized_session.session),
+    ]
+
+    subprocess.check_call(command, cwd=str(fast_tests_root))
+
+
+@skip_in_ci
+def test_smoke_test_on_execd_session(execd_session, fast_tests_root):
+    command = [
+        sys.executable,
+        "-m",
+        "cosmic_ray.tools.filters.line_filter",
+        str(execd_session.session),
+    ]
+
+    subprocess.check_call(command, cwd=str(fast_tests_root))
+


### PR DESCRIPTION
Closes #585

This PR introduces a new filter (`line_filter.py`, exposed as `cr-filter-lines`) that allows running Cosmic Ray only on specific lines defined in the config.

When working on a small part of the codebase (e.g. refactoring a function), it is useful to run mutation testing only on relevant lines instead of the whole module. This filter enables that in a simple and explicit way.

---

### What was added
- New filter: `line_filter.py`
- CLI tool: `cr-filter-lines`
- Configurable line ranges per file
- Basic smoke tests

---

### Configuration:

Supported formats in cr config file:

```
[cosmic-ray.filters.line-filter.lines]
"math.py" = "1-4"
"util.py" = ["4", "10-22"]
``` 

or

```
[cosmic-ray.filters.line-filter]
lines = { "my_math.py" = "2", "my_utils.py" = "3-4" }
``` 
Notes:
- Values can be "5", "10-20" or a list
- Multiple files supported
- Only mutations overlapping configured lines are executed
- Others are marked as SKIPPED


### Usage:

1. Configure the lines you want to mutate in the config file  
2. Initialize a Cosmic Ray session (init)  
3. Run the `cr-filter-lines` filter on the session  
```cr-filter-lines cosmic-ray-sql.sqlite --config cosmic-ray-config.toml --verbosity INFO``` 
5. Execute mutation testing as usual (exec)  

Summary:

Adds a simple way to focus mutation testing on selected lines.